### PR TITLE
update e2e tests and driver repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _WIP_
 This guide will walk you through the steps to configure and run the Azure Key Vault provider for Secret Store CSI driver on Kubernetes.
 
 ## Install the Secrets Store CSI Driver (Kubernetes Version 1.15.x+)
-Make sure you have followed the [Installation guide for the Secrets Store CSI Driver](https://github.com/deislabs/secrets-store-csi-driver#usage).
+Make sure you have followed the [Installation guide for the Secrets Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver#usage).
 
 
 The Azure Key Vault Provider offers two modes for accessing a Key Vault instance: 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
     mkdir -p '$(GOBIN)'
     mkdir -p '$(GOPATH)/pkg'
     mkdir -p '$(modulePath)'
-    mkdir -p '$(GOPATH)/src/github.com/deislabs/secrets-store-csi-driver'
+    mkdir -p '$(GOPATH)/src/k8s.io/secrets-store-csi-driver'
     shopt -s extglob
     mv !(gopath) '$(modulePath)'
     echo '##vso[task.prependpath]$(GOBIN)'
@@ -30,8 +30,8 @@ steps:
     go version
   displayName: 'Set up the Go workspace'
 - script: |
-    git clone https://github.com/deislabs/secrets-store-csi-driver.git $(GOPATH)/src/github.com/deislabs/secrets-store-csi-driver
-    sudo apt-get update && sudo apt-get install bats
+    git clone https://github.com/kubernetes-sigs/secrets-store-csi-driver.git $(GOPATH)/src/k8s.io/secrets-store-csi-driver
+    sudo add-apt-repository ppa:rmescandon/yq && sudo apt-get update && sudo apt-get install bats && sudo apt-get install yq
   workingDirectory: '$(modulePath)'
   displayName: 'Set up workspace and install dependencies'
 - script: |


### PR DESCRIPTION
- Update driver references to `kubernetes-sigs`
- Update provider installation step for e2e tests as provider charts have now been removed