### PR TITLE
update driver name in examples and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The Azure Key Vault Provider offers two modes for accessing a Key Vault instance
     volumes:
       - name: secrets-store-inline
         csi:
-          driver: secrets-store.csi.k8s.com
+          driver: secrets-store.csi.k8s.io
           readOnly: true
           volumeAttributes:
             secretProviderClass: "azure-kvname"

--- a/examples/nginx-pod-secrets-store-inline-volume-pod-identity.yaml
+++ b/examples/nginx-pod-secrets-store-inline-volume-pod-identity.yaml
@@ -15,7 +15,7 @@ spec:
   volumes:
     - name: secrets-store-inline
       csi:
-        driver: secrets-store.csi.k8s.com
+        driver: secrets-store.csi.k8s.io
         readOnly: true
         volumeAttributes:
           providerName: "azure"

--- a/examples/nginx-pod-secrets-store-inline-volume-secretproviderclass-podid.yaml
+++ b/examples/nginx-pod-secrets-store-inline-volume-secretproviderclass-podid.yaml
@@ -15,7 +15,7 @@ spec:
   volumes:
     - name: secrets-store01-inline
       csi:
-        driver: secrets-store.csi.k8s.com
+        driver: secrets-store.csi.k8s.io
         readOnly: true
         volumeAttributes:
           secretProviderClass: "azure-kvname-podid"

--- a/examples/nginx-pod-secrets-store-inline-volume-secretproviderclass.yaml
+++ b/examples/nginx-pod-secrets-store-inline-volume-secretproviderclass.yaml
@@ -13,7 +13,7 @@ spec:
   volumes:
     - name: secrets-store-inline
       csi:
-        driver: secrets-store.csi.k8s.com
+        driver: secrets-store.csi.k8s.io
         readOnly: true
         volumeAttributes:
           secretProviderClass: "azure-kvname"

--- a/examples/nginx-pod-secrets-store-inline-volume.yaml
+++ b/examples/nginx-pod-secrets-store-inline-volume.yaml
@@ -13,7 +13,7 @@ spec:
   volumes:
     - name: secrets-store-inline
       csi:
-        driver: secrets-store.csi.k8s.com
+        driver: secrets-store.csi.k8s.io
         readOnly: true
         volumeAttributes:
           providerName: "azure"

--- a/examples/pv-secrets-store-csi.yaml
+++ b/examples/pv-secrets-store-csi.yaml
@@ -9,7 +9,7 @@ spec:
     - ReadOnlyMany
   persistentVolumeReclaimPolicy: Retain
   csi:
-    driver: secrets-store.csi.k8s.com
+    driver: secrets-store.csi.k8s.io
     readOnly: true
     volumeHandle: kv
     volumeAttributes:

--- a/test/bats/tests/nginx-pod-secrets-store-inline-volume-crd.yaml
+++ b/test/bats/tests/nginx-pod-secrets-store-inline-volume-crd.yaml
@@ -13,7 +13,7 @@ spec:
   volumes:
     - name: secrets-store-inline
       csi:
-        driver: secrets-store.csi.k8s.com
+        driver: secrets-store.csi.k8s.io
         readOnly: true
         volumeAttributes:
           secretProviderClass: "azure"

--- a/test/bats/tests/nginx-pod-secrets-store-inline-volume.yaml
+++ b/test/bats/tests/nginx-pod-secrets-store-inline-volume.yaml
@@ -13,7 +13,7 @@ spec:
   volumes:
     - name: secrets-store-inline
       csi:
-        driver: secrets-store.csi.k8s.com
+        driver: secrets-store.csi.k8s.io
         readOnly: true
         volumeAttributes:
           providerName: "azure"


### PR DESCRIPTION
- Driver version `v0.0.8` has been released with the driver name changes. Updating all the examples and tests to reflect the new driver name. 