### PR TITLE
Upgrade to Helm 3 for E2E Tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,18 +54,13 @@ e2e-bootstrap:
 	# Download and install kind
 	curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output kind && chmod +x kind && sudo mv kind /usr/local/bin/
 	# Download and install Helm
-	curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
+	curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 	# Create kind cluster
 	kind create cluster --config kind-config.yaml --image kindest/node:v${KUBERNETES_VERSION}
 	# Build image
 	DOCKER_IMAGE="e2e/secrets-store-csi-driver-provider-azure" IMAGE_VERSION=e2e-$$(git rev-parse --short HEAD) make image
 	# Load image into kind cluster
 	kind load docker-image --name kind e2e/secrets-store-csi-driver-provider-azure:e2e-$$(git rev-parse --short HEAD)
-	# Set up tiller
-	kubectl --namespace kube-system --output yaml create serviceaccount tiller --dry-run | kubectl --kubeconfig $$(kind get kubeconfig-path)  apply -f -
-	kubectl create --output yaml clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller --dry-run | kubectl --kubeconfig $$(kind get kubeconfig-path) apply -f -
-	helm init --service-account tiller --upgrade --wait --kubeconfig $$(kind get kubeconfig-path)
-
 .PHONY: e2e-azure
 e2e-azure:
 	bats -t test/bats/azure.bats

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,7 @@ steps:
 - script: |
     make e2e-bootstrap
     export KUBECONFIG=$(kind get kubeconfig-path)
+    kubectl create ns dev
     make e2e-azure
   workingDirectory: '$(modulePath)'
   displayName: "e2e-azure"

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -21,7 +21,7 @@ setup() {
 }
 
 @test "install driver helm chart" {
-  run helm install ${GOPATH}/src/k8s.io/secrets-store-csi-driver/charts/secrets-store-csi-driver -n csi-secrets-store --namespace dev
+  run helm install csi-secrets-store ${GOPATH}/src/k8s.io/secrets-store-csi-driver/charts/secrets-store-csi-driver --namespace dev
   assert_success
 }
 


### PR DESCRIPTION
Fixes #40 
- [x] change the syntax of the helm install inside azure.bats
- [x] upgrade to helm 3 in e2e-bootstrap
- [x] Create `dev` namespace inside azure pipeline

Currently, with Helm 3 if you want to assign the installed chart to a specific namespace that doesn't exist, you must externally create that namespace (kubectl).  https://github.com/helm/helm/issues/6794