### PR TITLE
check key type before return

### DIFF
--- a/pkg/azure/provider.go
+++ b/pkg/azure/provider.go
@@ -427,8 +427,14 @@ func (p *Provider) GetKeyVaultObjectContent(ctx context.Context, objectType stri
 		if err != nil {
 			return "", wrapObjectTypeError(err, objectType, objectName, objectVersion)
 		}
-		// NOTE: we are writing the RSA modulus content of the key
-		return *keybundle.Key.N, nil
+		switch keybundle.Key.Kty {
+		case kv.RSA:
+			// NOTE: we are writing the RSA modulus content of the key
+			return *keybundle.Key.N, nil
+		default:
+			err := errors.Errorf("failed to get key. key type '%s' currently not supported", keybundle.Key.Kty)
+			return "", wrapObjectTypeError(err, objectType, objectName, objectVersion)
+		}
 	case VaultObjectTypeCertificate:
 		certbundle, err := kvClient.GetCertificate(ctx, *vaultURL, objectName, objectVersion)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, only RSA modulus is supported. The code panics for other key types. We should check the type of the key before returning.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: