### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,11 +312,11 @@ az vmss identity assign -g <RESOURCE GROUP> -n <K8S-AGENT-POOL-VMSS> --identitie
 
    ```bash
    # set policy to access keys in your Key Vault
-   az keyvault set-policy -n $KV_NAME --key-permissions get --spn <YOUR AZURE MANAGED IDENTITY CLIENT ID>
+   az keyvault set-policy -n $KV_NAME --key-permissions get --object-id <YOUR AZURE MANAGED IDENTITY PRINCIPAL ID>
    # set policy to access secrets in your Key Vault
-   az keyvault set-policy -n $KV_NAME --secret-permissions get --spn <YOUR AZURE MANAGED IDENTITY CLIENT ID>
+   az keyvault set-policy -n $KV_NAME --secret-permissions get --object-id <YOUR AZURE MANAGED IDENTITY PRINCIPAL ID>
    # set policy to access certs in your Key Vault
-   az keyvault set-policy -n $KV_NAME --certificate-permissions get --spn <YOUR AZURE MANAGED IDENTITY CLIENT ID>
+   az keyvault set-policy -n $KV_NAME --certificate-permissions get --object-id <YOUR AZURE MANAGED IDENTITY PRINCIPAL ID>
    ```
 
 4. Deploy your application. Specify `useVMManagedIdentity` to `true` and provide `userAssignedIdentityID`.
@@ -346,11 +346,11 @@ The output should contain `type: SystemAssigned`.
 
    ```bash
    # set policy to access keys in your Key Vault
-   az keyvault set-policy -n $KV_NAME --key-permissions get --spn <YOUR AZURE MANAGED IDENTITY CLIENT ID>
+   az keyvault set-policy -n $KV_NAME --key-permissions get --object-id <YOUR AZURE MANAGED IDENTITY PRINCIPAL ID>
    # set policy to access secrets in your Key Vault
-   az keyvault set-policy -n $KV_NAME --secret-permissions get --spn <YOUR AZURE MANAGED IDENTITY CLIENT ID>
+   az keyvault set-policy -n $KV_NAME --secret-permissions get --object-id <YOUR AZURE MANAGED IDENTITY PRINCIPAL ID>
    # set policy to access certs in your Key Vault
-   az keyvault set-policy -n $KV_NAME --certificate-permissions get --spn <YOUR AZURE MANAGED IDENTITY CLIENT ID>
+   az keyvault set-policy -n $KV_NAME --certificate-permissions get --object-id <YOUR AZURE MANAGED IDENTITY PRINCIPAL ID>
    ```
 
 3. Deploy your application. Specify `useVMManagedIdentity` to `true`.


### PR DESCRIPTION
incorrect syntax for setting key vault access policies.
When setting an access policy with a managed identity, it should be --object-id, not -spn

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: