### PR TITLE
add user agent with version number

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -37,3 +37,8 @@ func PrintVersion() (err error) {
 	fmt.Printf(string(res) + "\n")
 	return
 }
+
+// GetUserAgent returns UserAgent string to append to the agent identifier.
+func GetUserAgent() string {
+	return fmt.Sprintf("csi-secrets-store/%s", BuildVersion)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `csi-secrets-store/"Version"` user agent to key vault client and ADAL calls

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #91 

**Special notes for your reviewer**: