### PR TITLE
update node selector to kubernetes.io/os

### DIFF
--- a/charts/csi-secrets-store-provider-azure/README.md
+++ b/charts/csi-secrets-store-provider-azure/README.md
@@ -31,10 +31,10 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `image.tag` | Azure Keyvault Provider image | `0.0.6` |
 | `linux.enabled` | Install azure keyvault provider on linux nodes | true |
-| `linux.nodeSelector` | Node Selector for the daemonset on linux nodes | `beta.kubernetes.io/os: linux` |
+| `linux.nodeSelector` | Node Selector for the daemonset on linux nodes | `kubernetes.io/os: linux` |
 | `linux.resources` | Resource limit for provider pods on linux nodes | `requests.cpu: 50m`<br>`requests.memory: 100Mi`<br>`limits.cpu: 50m`<br>`limits.memory: 100Mi` |
 | `windows.enabled` | Install azure keyvault provider on windows nodes | false |
-| `windows.nodeSelector` | Node Selector for the daemonset on windows nodes | `beta.kubernetes.io/os: windows` |
+| `windows.nodeSelector` | Node Selector for the daemonset on windows nodes | `kubernetes.io/os: windows` |
 | `windows.resources` | Resource limit for provider pods on windows nodes | `requests.cpu: 100m`<br>`requests.memory: 200Mi`<br>`limits.cpu: 100m`<br>`limits.memory: 200Mi` |
 | `secrets-store-csi-driver.install` | Install secrets-store-csi-driver with this chart | true |
 | `secrets-store-csi-driver.linux.enabled` | Install secrets-store-csi-driver on linux nodes | true |

--- a/charts/csi-secrets-store-provider-azure/README.md
+++ b/charts/csi-secrets-store-provider-azure/README.md
@@ -31,10 +31,10 @@ The following table lists the configurable parameters of the csi-secrets-store-p
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `image.tag` | Azure Keyvault Provider image | `0.0.6` |
 | `linux.enabled` | Install azure keyvault provider on linux nodes | true |
-| `linux.nodeSelector` | Node Selector for the daemonset on linux nodes | `kubernetes.io/os: linux` |
+| `linux.nodeSelector` | Node Selector for the daemonset on linux nodes | `{}` |
 | `linux.resources` | Resource limit for provider pods on linux nodes | `requests.cpu: 50m`<br>`requests.memory: 100Mi`<br>`limits.cpu: 50m`<br>`limits.memory: 100Mi` |
 | `windows.enabled` | Install azure keyvault provider on windows nodes | false |
-| `windows.nodeSelector` | Node Selector for the daemonset on windows nodes | `kubernetes.io/os: windows` |
+| `windows.nodeSelector` | Node Selector for the daemonset on windows nodes | `{}` |
 | `windows.resources` | Resource limit for provider pods on windows nodes | `requests.cpu: 100m`<br>`requests.memory: 200Mi`<br>`limits.cpu: 100m`<br>`limits.memory: 200Mi` |
 | `secrets-store-csi-driver.install` | Install secrets-store-csi-driver with this chart | true |
 | `secrets-store-csi-driver.linux.enabled` | Install secrets-store-csi-driver on linux nodes | true |

--- a/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer-windows.yaml
+++ b/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer-windows.yaml
@@ -32,8 +32,9 @@ spec:
           hostPath:
             path: "C:\\k\\secrets-store-csi-providers"
             type: DirectoryOrCreate
-{{- with .Values.windows.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+        kubernetes.io/os: windows
+{{- if .Values.windows.nodeSelector }}
+{{- toYaml .Values.windows.nodeSelector | nindent 8 }}
 {{- end }}
 {{- end -}}

--- a/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
+++ b/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
@@ -31,8 +31,9 @@ spec:
         - name: providervol
           hostPath:
             path: "/etc/kubernetes/secrets-store-csi-providers"
-{{- with .Values.linux.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+        kubernetes.io/os: linux
+{{- if .Values.linux.nodeSelector }}
+{{- toYaml .Values.linux.nodeSelector | nindent 8 }}
 {{- end }}
 {{- end -}}

--- a/charts/csi-secrets-store-provider-azure/values.yaml
+++ b/charts/csi-secrets-store-provider-azure/values.yaml
@@ -4,8 +4,7 @@ image:
   pullPolicy: IfNotPresent
 
 linux:
-  nodeSelector:
-    kubernetes.io/os: linux
+  nodeSelector: {}
   enabled: true
   resources:
     requests:
@@ -16,8 +15,7 @@ linux:
       memory: 100Mi
 
 windows:
-  nodeSelector:
-    kubernetes.io/os: windows
+  nodeSelector: {}
   enabled: false
   resources:
     requests:

--- a/charts/csi-secrets-store-provider-azure/values.yaml
+++ b/charts/csi-secrets-store-provider-azure/values.yaml
@@ -5,7 +5,7 @@ image:
 
 linux:
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
   enabled: true
   resources:
     requests:
@@ -17,7 +17,7 @@ linux:
 
 windows:
   nodeSelector:
-    beta.kubernetes.io/os: windows
+    kubernetes.io/os: windows
   enabled: false
   resources:
     requests:

--- a/deployment/provider-azure-installer-windows.yaml
+++ b/deployment/provider-azure-installer-windows.yaml
@@ -16,7 +16,7 @@ spec:
         app: csi-secrets-store-provider-azure
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: windows
+        kubernetes.io/os: windows
       containers:
         - name: provider-azure-installer
           image: mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.6

--- a/deployment/provider-azure-installer.yaml
+++ b/deployment/provider-azure-installer.yaml
@@ -37,4 +37,4 @@ spec:
           hostPath:
             path: "/etc/kubernetes/secrets-store-csi-providers"
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux


### PR DESCRIPTION
**What this PR does / why we need it**:
- Update `nodeSelector` to `kubernetes.io/os` as `beta.kubernetes.io/os` will be deprecated in 1.19

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: