### PR TITLE
add kubectl node version to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -26,5 +26,5 @@ assignees: ''
 
 - Secrets Store CSI Driver version: (use the image tag):
 - Azure Key Vault provider version: (use the image tag):
-- Kubernetes version: (use `kubectl version`):
+- Kubernetes version: (use `kubectl version` and `kubectl get nodes -o wide`):
 - Cluster type: (e.g. AKS, aks-engine, etc):


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `kubectl get nodes -o wide` to issue template as `kubectl version` only provides the server version.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: