### PR TITLE
chore: set context timeout for access to kv

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,12 +16,13 @@ import (
 )
 
 var (
-	attributes  = pflag.String("attributes", "", "volume attributes")
-	secrets     = pflag.String("secrets", "", "node publish ref secret")
-	targetPath  = pflag.String("targetPath", "", "Target path to write data.")
-	permission  = pflag.String("permission", "", "File permission")
-	debug       = pflag.Bool("debug", false, "sets log to debug level")
-	versionInfo = pflag.Bool("version", false, "prints the version information")
+	attributes     = pflag.String("attributes", "", "volume attributes")
+	secrets        = pflag.String("secrets", "", "node publish ref secret")
+	targetPath     = pflag.String("targetPath", "", "Target path to write data.")
+	permission     = pflag.String("permission", "", "File permission")
+	debug          = pflag.Bool("debug", false, "sets log to debug level")
+	versionInfo    = pflag.Bool("version", false, "prints the version information")
+	contextTimeout = pflag.Int("context-timeout", 110, "context timeout in seconds for provider calls")
 )
 
 // LogHook is used to setup custom hooks
@@ -68,7 +69,7 @@ func main() {
 	// setting the context to 1m50s will ensure request is terminated if taking longer/unable to establish connection due to underlying network error and
 	// the correct error is returned back to the driver
 	// Value is set to 1m50s to provide enough time for driver to complete outstanding operations
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute+50*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(*contextTimeout))
 	defer cancel()
 
 	err = provider.MountSecretsStoreObjectContent(ctx, attrib, secret, *targetPath, filePermission)

--- a/pkg/azure/provider.go
+++ b/pkg/azure/provider.go
@@ -402,6 +402,7 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 	p.TenantID = tenantID
 
 	for _, keyVaultObject := range keyVaultObjects {
+		log.Infof("fetching object: %s, type: %s from key vault", keyVaultObject.ObjectName, keyVaultObject.ObjectType)
 		content, err := p.GetKeyVaultObjectContent(ctx, keyVaultObject.ObjectType, keyVaultObject.ObjectName, keyVaultObject.ObjectVersion)
 		if err != nil {
 			return err
@@ -412,10 +413,9 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 			fileName = keyVaultObject.ObjectAlias
 		}
 		if err := ioutil.WriteFile(filepath.Join(targetPath, fileName), objectContent, permission); err != nil {
-			return errors.Wrapf(err, "secrets store csi driver failed to mount %s at %s", fileName, targetPath)
+			return errors.Wrapf(err, "failed to mount %s at %s", fileName, targetPath)
 		}
-		log.Infof("secrets store csi driver mounted %s", fileName)
-		log.Infof("Mount point: %s", targetPath)
+		log.Infof("successfully mounted %s", fileName)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
- Sets context timeout to 1m50s for access to kv. This ensures the request is terminated and error is returned when time to access kv takes > 2m. The default volume timeout for kubelet is 2m3s and this change honors the value. If the context in provider is not set, then the driver will terminate the process based on the context, but the error from provider will not be surfaced to the user. 

Sample error when network policies deny outbound traffic in cluster - 

```
time="2020-07-09T19:07:35Z" level=info msg="time=\"2020-07-09T18:57:35Z\" level=info msg=\"using pod identity to access keyvault\"\ntime=\"2020-07-09T18:57:35Z\" level=info msg=\"mounting secrets store object content for kube-system/nginx-secrets-store-env-var\"\ntime=\"2020-07-09T18:57:35Z\" level=info msg=\"objects: array:\\n  - |\\n    objectName: kv\\n    objectType: secret           # object types: secret, key or cert\\n    objectVersion: \\\"\\\"            # [OPTIONAL] object versions, default to latest if empty\\n\"\ntime=\"2020-07-09T18:57:35Z\" level=info msg=\"unmarshaled keyVaultObjects: [{kv   secret}]\"\ntime=\"2020-07-09T18:57:35Z\" level=info msg=\"keyVaultObjects len: 1\"\ntime=\"2020-07-09T18:57:35Z\" level=info msg=\"azure: using pod identity to retrieve token\"\ntime=\"2020-07-09T18:58:05Z\" level=info msg=\"accesstoken: eyJ0##### REDACTED #####l20w\"\ntime=\"2020-07-09T18:58:05Z\" level=info msg=\"clientid: ee32##### REDACTED #####0e49\"\n"
time="2020-07-09T19:07:35Z" level=error msg="error invoking provider, err: exit status 1, output: time=\"2020-07-09T19:07:35Z\" level=fatal msg=\"[error] : failed to get objectType:secret, objectName:kv, objectVersion:: keyvault.BaseClient#GetSecret: Failure sending request: StatusCode=0 -- Original Error: Get https://kv.vault.azure.net/secrets/kv/?api-version=2016-10-01: dial tcp: i/o timeout\"\n for pod: c1f448b7-b752-431e-ad33-521c2abb8204, ns: kube-system"
time="2020-07-09T19:07:35Z" level=error msg="GRPC error: error mounting secret time=\"2020-07-09T19:07:35Z\" level=fatal msg=\"[error] : failed to get objectType:secret, objectName:kv, objectVersion:: keyvault.BaseClient#GetSecret: Failure sending request: StatusCode=0 -- Original Error: Get https://kv.vault.azure.net/secrets/kv/?api-version=2016-10-01: dial tcp: i/o timeout\"\n for pod: c1f448b7-b752-431e-ad33-521c2abb8204, ns: kube-system"
```

The request only times out after 10m as there is no context defined

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: