### PR TITLE
feat: allow defining a custom azure environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To provide identity to access key vault, refer to the following [section](#provi
       userAssignedIdentityID: "client_id"  # [OPTIONAL available for version > 0.0.4] use the client id to specify which user assigned managed identity to use. If using a user assigned identity as the VM's managed identity, then specify the identity's client id. If empty, then defaults to use the system assigned identity on the VM
       keyvaultName: "kvname"          # the name of the KeyVault
       cloudName: ""          # [OPTIONAL available for version > 0.0.4] if not provided, azure environment will default to AzurePublicCloud
+      cloudEnvFileName: ""   # [OPTIONAL available for version > 0.0.7] use to define path to file for populating azure environment
       objects:  |
         array:
           - |
@@ -113,6 +114,7 @@ To provide identity to access key vault, refer to the following [section](#provi
   | userAssignedIdentityID | no       | [__*available for version > 0.0.4*__] the user assigned identity ID is required for VMSS User Assigned Managed Identity mode  | ""       |
   | keyvaultName           | yes      | name of a Key Vault instance                                    | ""            |
   | cloudName              | no       | [__*available for version > 0.0.4*__] name of the azure cloud based on azure go sdk (AzurePublicCloud,AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud)| "" |
+  | cloudEnvFileName       | no       | [__*available for version > 0.0.7*__] path to the file to be used while populating the Azure Environment | "" |
   | objects                | yes      | a string of arrays of strings                                   | ""            |
   | objectName             | yes      | name of a Key Vault object                                      | ""            |
   | objectAlias            | no       | [__*available for version > 0.0.4*__] specify the filename of the object when written to disk - defaults to objectName if not provided | "" |

--- a/pkg/azure/provider_test.go
+++ b/pkg/azure/provider_test.go
@@ -2,6 +2,9 @@ package azure
 
 import (
 	"context"
+	"io"
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -279,5 +282,32 @@ Uz7sJMWoq7mOrINHQ0ZmaiE=
 				t.Fatalf("certificate and key mismatch")
 			}
 		})
+	}
+}
+
+func TestParseAzureEnvironmentAzureStackCloud(t *testing.T) {
+	azureStackCloudEnvName := "AZURESTACKCLOUD"
+	file, err := ioutil.TempFile("", "ut")
+	defer os.Remove(file.Name())
+	if err != nil {
+		t.Fatalf("expected error to be nil, got: %+v", err)
+	}
+	_, err = io.WriteString(file, `{}`)
+	if err != nil {
+		t.Fatalf("expected error to be nil, got: %+v", err)
+	}
+	_, err = ParseAzureEnvironment(azureStackCloudEnvName)
+	if err == nil {
+		t.Fatalf("expected error to be not nil as AZURE_ENVIRONMENT_FILEPATH is not set")
+	}
+
+	err = setAzureEnvironmentFilePath(file.Name())
+	defer os.Unsetenv(azure.EnvironmentFilepathName)
+	if err != nil {
+		t.Fatalf("expected error to be nil, got: %+v", err)
+	}
+	_, err = ParseAzureEnvironment(azureStackCloudEnvName)
+	if err != nil {
+		t.Fatalf("expected error to be nil, got: %+v", err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If `cloudEnvFileName ` is defined, then provider can set the [AZURE_ENVIRONMENT_FILEPATH](https://github.com/Azure/go-autorest/blob/master/autorest/azure/environments.go#L28) env var. The SDK should then be able to [read](https://github.com/Azure/go-autorest/blob/master/autorest/azure/environments.go#L224-L226) from the file which is already on host for `AzureStackCloud`. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #144 

**Special notes for your reviewer**: