### PR TITLE
Change version required for using objectAlias

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To provide identity to access key vault, refer to the following [section](#provi
         array:
           - |
             objectName: secret1
-            objectAlias: SECRET_1     # [OPTIONAL available for version > 0.0.4] object alias
+            objectAlias: SECRET_1     # [OPTIONAL available for version > 0.0.5] object alias
             objectType: secret        # object types: secret, key or cert
             objectVersion: ""         # [OPTIONAL] object versions, default to latest if empty
           - |


### PR DESCRIPTION
**What this PR does / why we need it**:
When setting up the secret store csi provider we had version 0.0.4 but according to [this issue](https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/24) this was actually released in 0.0.5

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I'm a bit confused in general about the `>` in the version requirements? Do they mean any version _above_ 0.0.4 because in that case they would be correct however the `cloudEnvFileName` specifies `> 0.0.7` which doesn't exist yet since the latest release is 0.0.7.