### PR TITLE
fix: update kv endpoint suffix for custom cloud

### DIFF
--- a/pkg/azure/provider.go
+++ b/pkg/azure/provider.go
@@ -211,11 +211,7 @@ func (p *Provider) getVaultURL(ctx context.Context) (vaultURL *string, err error
 		return nil, errors.Errorf("Invalid vault name: %q, must match [-a-zA-Z0-9]{3,24}", p.KeyvaultName)
 	}
 
-	vaultDnsSuffix, err := GetVaultDNSSuffix(p.AzureCloudEnvironment.Name)
-	if err != nil {
-		return nil, err
-	}
-	vaultDnsSuffixValue := *vaultDnsSuffix
+	vaultDnsSuffixValue := p.AzureCloudEnvironment.KeyVaultDNSSuffix
 	vaultUri := "https://" + p.KeyvaultName + "." + vaultDnsSuffixValue + "/"
 	return &vaultUri, nil
 }
@@ -567,15 +563,6 @@ func (p *Provider) GetKeyVaultObjectContent(ctx context.Context, kvObject KeyVau
 
 func wrapObjectTypeError(err error, objectType, objectName, objectVersion string) error {
 	return errors.Wrapf(err, "failed to get objectType:%s, objectName:%s, objectVersion:%s", objectType, objectName, objectVersion)
-}
-
-func GetVaultDNSSuffix(cloudName string) (vaultTld *string, err error) {
-	environment, err := ParseAzureEnvironment(cloudName)
-	if err != nil {
-		return nil, err
-	}
-
-	return &environment.KeyVaultDNSSuffix, nil
 }
 
 //RedactClientID Apply regex to a sensitive string and return the redacted value

--- a/pkg/azure/provider_test.go
+++ b/pkg/azure/provider_test.go
@@ -12,41 +12,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 )
 
-func TestGetVaultDNSSuffix(t *testing.T) {
-	cases := []struct {
-		cloudName string
-		expected  *string
-	}{
-		{
-			cloudName: "",
-			expected:  &azure.PublicCloud.KeyVaultDNSSuffix,
-		},
-		{
-			cloudName: "AZURECHINACLOUD",
-			expected:  &azure.ChinaCloud.KeyVaultDNSSuffix,
-		},
-		{
-			cloudName: "AZUREGERMANCLOUD",
-			expected:  &azure.GermanCloud.KeyVaultDNSSuffix,
-		},
-		{
-			cloudName: "AZUREPUBLICCLOUD",
-			expected:  &azure.PublicCloud.KeyVaultDNSSuffix,
-		},
-		{
-			cloudName: "AZUREUSGOVERNMENTCLOUD",
-			expected:  &azure.USGovernmentCloud.KeyVaultDNSSuffix,
-		},
-	}
-
-	for _, tc := range cases {
-		actual, _ := GetVaultDNSSuffix(tc.cloudName)
-		if !strings.EqualFold(*tc.expected, *actual) {
-			t.Fatalf("expected: %v, got: %v", *tc.expected, *actual)
-		}
-	}
-}
-
 func TestGetVaultURL(t *testing.T) {
 	testEnvs := []string{"", "AZUREPUBLICCLOUD", "AZURECHINACLOUD", "AZUREGERMANCLOUD", "AZUREUSGOVERNMENTCLOUD"}
 	vaultDNSSuffix := []string{"vault.azure.net", "vault.azure.net", "vault.azure.cn", "vault.microsoftazure.de", "vault.usgovcloudapi.net"}


### PR DESCRIPTION
**What this PR does / why we need it**:
For custom clouds, the cloud name will be set to `custom`. If `p.AzureCloudEnvironment.Name` is used to ParseAzureEnvironment the second time, it'll result in cloud name `custom` not found error. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: