### PR TITLE
Add imagePullSecretes to the Helm chart

### DIFF
--- a/charts/csi-secrets-store-provider-azure/Chart.yaml
+++ b/charts/csi-secrets-store-provider-azure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: csi-secrets-store-provider-azure
-version: 0.0.10
+version: 0.0.11
 appVersion: 0.0.8
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart to install the Secrets Store CSI Driver and the Azure Keyvault Provider inside a Kubernetes cluster.

--- a/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer-windows.yaml
+++ b/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer-windows.yaml
@@ -15,6 +15,12 @@ spec:
     metadata:
 {{ include "sscdpa.labels" . | indent 6 }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: csi-secrets-store-provider-azure
       containers:
         - name: provider-azure-installer

--- a/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
+++ b/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
@@ -15,6 +15,12 @@ spec:
     metadata:
 {{ include "sscdpa.labels" . | indent 6 }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: csi-secrets-store-provider-azure
       containers:
         - name: provider-azure-installer

--- a/charts/csi-secrets-store-provider-azure/values.yaml
+++ b/charts/csi-secrets-store-provider-azure/values.yaml
@@ -3,6 +3,10 @@ image:
   tag: 0.0.8
   pullPolicy: IfNotPresent
 
+# One or more secrets to be used when pulling images
+imagePullSecrets: []
+# - registrySecretName
+
 linux:
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
Signed-off-by: Armin <armin@coralic.nl>

**What this PR does / why we need it**:

Adding the imagePullSecrets to the Helm deployments to allow authenticated Docker registries.
