### PR TITLE
chore: add manifest staging dir to hold new manifests

### DIFF
--- a/manifest_staging/charts/csi-secrets-store-provider-azure/Chart.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: csi-secrets-store-provider-azure
+version: 0.0.10
+appVersion: 0.0.8
+kubeVersion: ">=1.16.0-0"
+description: A Helm chart to install the Secrets Store CSI Driver and the Azure Keyvault Provider inside a Kubernetes cluster.
+sources:
+  - https://github.com/Azure/secrets-store-csi-driver-provider-azure
+home: https://github.com/Azure/secrets-store-csi-driver-provider-azure
+maintainers:
+  - name: Anish Ramasekar
+    email: anish.ramasekar@gmail.com

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/README.md
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/README.md
@@ -1,0 +1,80 @@
+# csi-secrets-store-provider-azure
+
+Azure Key Vault provider for Secrets Store CSI driver allows you to get secret contents stored in Azure Key Vault instance and use the Secrets Store CSI driver interface to mount them into Kubernetes pods.
+
+## Helm chart, Secrets Store CSI Driver and Key Vault Provider versions
+
+| Helm Chart Version | Secrets Store CSI Driver Version | Azure Key Vault Provider Version |
+| ------------------ | -------------------------------- | -------------------------------- |
+| `0.0.5`            | `0.0.9`                          | `0.0.5`                          |
+| `0.0.6`            | `0.0.10`                         | `0.0.5`                          |
+| `0.0.7`            | `0.0.11`                         | `0.0.6`                          |
+| `0.0.8`            | `0.0.11`                         | `0.0.7`                          |
+| `0.0.9`            | `0.0.12`                         | `0.0.7`                          |
+| `0.0.10`           | `0.0.13`                         | `0.0.8`                          |
+
+## Installation
+
+Quick start instructions for the setup and configuration of secrets-store-csi-driver and azure keyvault provider using Helm.
+
+### Prerequisites
+
+- [Helm3](https://helm.sh/docs/intro/quickstart/#install-helm)
+
+### Installing the Chart
+
+- This chart installs the [secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) and the azure keyvault provider for the driver
+
+```shell
+$ helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
+$ helm install csi-secrets-store-provider-azure/csi-secrets-store-provider-azure --generate-name
+```
+
+### Configuration
+
+The following table lists the configurable parameters of the csi-secrets-store-provider-azure chart and their default values.
+
+> Refer to [doc](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/charts/secrets-store-csi-driver/README.md) for configurable parameters of the secrets-store-csi-driver chart.
+
+| Parameter                                                        | Description                                                                                                                   | Default                                                                                          |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `nameOverride`                                                   | String to partially override csi-secrets-store-provider-azure.fullname template with a string (will prepend the release name) | `""`                                                                                             |
+| `fullnameOverride`                                               | String to fully override csi-secrets-store-provider-azure.fullname template with a string                                     | `""`                                                                                             |
+| `image.repository`                                               | Image repository                                                                                                              | `mcr.microsoft.com/k8s/csi/secrets-store/provider-azure`                                         |
+| `image.pullPolicy`                                               | Image pull policy                                                                                                             | `IfNotPresent`                                                                                   |
+| `image.tag`                                                      | Azure Keyvault Provider image                                                                                                 | `0.0.8`                                                                                          |
+| `linux.enabled`                                                  | Install azure keyvault provider on linux nodes                                                                                | true                                                                                             |
+| `linux.nodeSelector`                                             | Node Selector for the daemonset on linux nodes                                                                                | `{}`                                                                                             |
+| `linux.tolerations`                                              | Tolerations for the daemonset on linux nodes                                                                                  | `{}`                                                                                             |
+| `linux.resources`                                                | Resource limit for provider pods on linux nodes                                                                               | `requests.cpu: 50m`<br>`requests.memory: 100Mi`<br>`limits.cpu: 50m`<br>`limits.memory: 100Mi`   |
+| `windows.enabled`                                                | Install azure keyvault provider on windows nodes                                                                              | false                                                                                            |
+| `windows.nodeSelector`                                           | Node Selector for the daemonset on windows nodes                                                                              | `{}`                                                                                             |
+| `windows.tolerations`                                            | Tolerations for the daemonset on windows nodes                                                                                | `{}`                                                                                             |
+| `windows.resources`                                              | Resource limit for provider pods on windows nodes                                                                             | `requests.cpu: 100m`<br>`requests.memory: 200Mi`<br>`limits.cpu: 100m`<br>`limits.memory: 200Mi` |
+| `secrets-store-csi-driver.install`                               | Install secrets-store-csi-driver with this chart                                                                              | true                                                                                             |
+| `secrets-store-csi-driver.linux.enabled`                         | Install secrets-store-csi-driver on linux nodes                                                                               | true                                                                                             |
+| `secrets-store-csi-driver.linux.kubeletRootDir`                  | Configure the kubelet root dir                                                                                                | `/var/lib/kubelet`                                                                               |
+| `secrets-store-csi-driver.linux.metricsAddr`                     | The address the metric endpoint binds to                                                                                      | `:8080`                                                                                          |
+| `secrets-store-csi-driver.linux.image.repository`                | Driver Linux image repository                                                                                                 | `mcr.microsoft.com/k8s/csi/secrets-store/driver`                                                 |
+| `secrets-store-csi-driver.linux.image.pullPolicy`                | Driver Linux image pull policy                                                                                                | `IfNotPresent`                                                                                   |
+| `secrets-store-csi-driver.linux.image.tag`                       | Driver Linux image tag                                                                                                        | `v0.0.13`                                                                                        |
+| `secrets-store-csi-driver.linux.registrarImage.repository`       | Driver Linux node-driver-registrar image repository                                                                           | `mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar`                                 |
+| `secrets-store-csi-driver.linux.registrarImage.pullPolicy`       | Driver Linux node-driver-registrar image pull policy                                                                          | `IfNotPresent`                                                                                   |
+| `secrets-store-csi-driver.linux.registrarImage.tag`              | Driver Linux node-driver-registrar image tag                                                                                  | `v1.2.0`                                                                                         |
+| `secrets-store-csi-driver.linux.livenessProbeImage.repository`   | Driver Linux liveness-probe image repository                                                                                  | `mcr.microsoft.com/oss/kubernetes-csi/livenessprobe`                                             |
+| `secrets-store-csi-driver.linux.livenessProbeImage.pullPolicy`   | Driver Linux liveness-probe image pull policy                                                                                 | `IfNotPresent`                                                                                   |
+| `secrets-store-csi-driver.linux.livenessProbeImage.tag`          | Driver Linux liveness-probe image tag                                                                                         | `v2.0.0`                                                                                         |
+| `secrets-store-csi-driver.windows.enabled`                       | Install secrets-store-csi-driver on windows nodes                                                                             | false                                                                                            |
+| `secrets-store-csi-driver.windows.kubeletRootDir`                | Configure the kubelet root dir                                                                                                | `C:\var\lib\kubelet`                                                                             |
+| `secrets-store-csi-driver.windows.metricsAddr`                   | The address the metric endpoint binds to                                                                                      | `:8080`                                                                                          |
+| `secrets-store-csi-driver.windows.image.repository`              | Driver Windows image repository                                                                                               | `mcr.microsoft.com/k8s/csi/secrets-store/driver`                                                 |
+| `secrets-store-csi-driver.windows.image.pullPolicy`              | Driver Windows image pull policy                                                                                              | `IfNotPresent`                                                                                   |
+| `secrets-store-csi-driver.windows.image.tag`                     | Driver Windows image tag                                                                                                      | `v0.0.13`                                                                                        |
+| `secrets-store-csi-driver.windows.registrarImage.repository`     | Driver Windows node-driver-registrar image repository                                                                         | `mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar`                                 |
+| `secrets-store-csi-driver.windows.registrarImage.pullPolicy`     | Driver Windows node-driver-registrar image pull policy                                                                        | `IfNotPresent`                                                                                   |
+| `secrets-store-csi-driver.windows.registrarImage.tag`            | Driver Windows node-driver-registrar image tag                                                                                | `v1.2.1-alpha.1-windows-1809-amd64`                                                              |
+| `secrets-store-csi-driver.windows.livenessProbeImage.repository` | Driver Windows liveness-probe image repository                                                                                | `mcr.microsoft.com/oss/kubernetes-csi/livenessprobe`                                             |
+| `secrets-store-csi-driver.windows.livenessProbeImage.pullPolicy` | Driver Windows liveness-probe image pull policy                                                                               | `IfNotPresent`                                                                                   |
+| `secrets-store-csi-driver.windows.livenessProbeImage.tag`        | Driver Windows liveness-probe image tag                                                                                       | `v2.0.1-alpha.1-windows-1809-amd64`                                                              |
+| `secrets-store-csi-driver.logLevel.debug`                        | Enable debug logging                                                                                                          | `true`                                                                                           |
+| `rbac.install`                                                   | Install default service account                                                                                               | true                                                                                             |

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/requirements.lock
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: secrets-store-csi-driver
+  repository: https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
+  version: 0.0.13
+digest: sha256:eb749015c8952a2eb1f39c23a832158492ec6e6e44f816759cc08e3805558b78
+generated: "2020-08-18T18:21:06.253399-07:00"

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/requirements.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: secrets-store-csi-driver
+  repository: https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
+  version: 0.0.13
+  condition: secrets-store-csi-driver.install

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/_helpers.tpl
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sscdpa.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sscdpa.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Standard labels for helm resources
+*/}}
+{{- define "sscdpa.labels" -}}
+labels:
+  app.kubernetes.io/instance: "{{ .Release.Name }}"
+  app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+  app.kubernetes.io/name: "{{ template "sscdpa.name" . }}"
+  app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+  app: {{ template "sscdpa.name" . }}
+  helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- end -}}

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer-windows.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer-windows.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.windows.enabled}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "sscdpa.fullname" . }}-windows
+  namespace: {{ .Release.Namespace }}
+{{ include "sscdpa.labels" . | indent 2 }}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: {{ template "sscdpa.name" . }}
+  template:
+    metadata:
+{{ include "sscdpa.labels" . | indent 6 }}
+    spec:
+      serviceAccountName: csi-secrets-store-provider-azure
+      containers:
+        - name: provider-azure-installer
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.windows.resources | indent 12 }}
+          env:
+          - name: TARGET_DIR
+            value: "C:\\k\\secrets-store-csi-providers"
+          volumeMounts:
+            - mountPath: "C:\\k\\secrets-store-csi-providers"
+              name: providervol
+      volumes:
+        - name: providervol
+          hostPath:
+            path: "C:\\k\\secrets-store-csi-providers"
+            type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: windows
+{{- if .Values.windows.nodeSelector }}
+{{- toYaml .Values.windows.nodeSelector | nindent 8 }}
+{{- end }}
+{{- with .Values.windows.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- end -}}

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.linux.enabled}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "sscdpa.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{ include "sscdpa.labels" . | indent 2 }}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: {{ template "sscdpa.name" . }}
+  template:
+    metadata:
+{{ include "sscdpa.labels" . | indent 6 }}
+    spec:
+      serviceAccountName: csi-secrets-store-provider-azure
+      containers:
+        - name: provider-azure-installer
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.linux.resources | indent 12 }}
+          env:
+          - name: TARGET_DIR
+            value: "/etc/kubernetes/secrets-store-csi-providers"
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+      volumes:
+        - name: providervol
+          hostPath:
+            path: "/etc/kubernetes/secrets-store-csi-providers"
+      nodeSelector:
+        kubernetes.io/os: linux
+{{- if .Values.linux.nodeSelector }}
+{{- toYaml .Values.linux.nodeSelector | nindent 8 }}
+{{- end }}
+{{- with .Values.linux.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- end -}}

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/serviceaccount.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{ if .Values.rbac.install }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-azure
+  namespace: {{ .Release.Namespace }}
+{{ include "sscdpa.labels" . | indent 2 }}
+{{ end }}

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/values.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/values.yaml
@@ -1,0 +1,74 @@
+image:
+  repository: mcr.microsoft.com/k8s/csi/secrets-store/provider-azure
+  tag: 0.0.8
+  pullPolicy: IfNotPresent
+
+linux:
+  nodeSelector: {}
+  tolerations: []
+  enabled: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 100Mi
+    limits:
+      cpu: 50m
+      memory: 100Mi
+
+windows:
+  nodeSelector: {}
+  tolerations: []
+  enabled: false
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+    limits:
+      cpu: 100m
+      memory: 200Mi
+
+## Configuration values for the secrets-store-csi-driver dependency.
+## ref: https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/master/charts/secrets-store-csi-driver/README.md
+##
+secrets-store-csi-driver:
+  install: true
+  linux:
+    enabled: true
+    kubeletRootDir: /var/lib/kubelet
+    metricsAddr: ":8080"
+    image:
+      repository: mcr.microsoft.com/k8s/csi/secrets-store/driver
+      tag: v0.0.13
+      pullPolicy: IfNotPresent
+    registrarImage:
+      repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar
+      tag: v1.2.0
+      pullPolicy: IfNotPresent
+    livenessProbeImage:
+      repository: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe
+      tag: v2.0.0
+      pullPolicy: IfNotPresent
+
+  windows:
+    enabled: false
+    kubeletRootDir: C:\var\lib\kubelet
+    metricsAddr: ":8080"
+    image:
+      repository: mcr.microsoft.com/k8s/csi/secrets-store/driver
+      tag: v0.0.13
+      pullPolicy: IfNotPresent
+    registrarImage:
+      repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar
+      tag: v1.2.1-alpha.1-windows-1809-amd64
+      pullPolicy: IfNotPresent
+    livenessProbeImage:
+      repository: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe
+      tag: v2.0.1-alpha.1-windows-1809-amd64
+      pullPolicy: IfNotPresent
+
+  logLevel:
+    debug: true
+
+## Install default service account
+rbac:
+  install: true

--- a/manifest_staging/deployment/pod-security-policy.yaml
+++ b/manifest_staging/deployment/pod-security-policy.yaml
@@ -1,0 +1,97 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: allow-csi-driver
+spec:
+  seLinux:
+    rule: RunAsAny
+  volumes:
+  - csi
+  - hostPath
+  - secret
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  privileged: true
+  hostNetwork: true
+  hostPorts:
+    - min: 9808
+      max: 9808
+  allowedHostPaths:
+    - pathPrefix: /etc/kubernetes/secrets-store-csi-providers
+    - pathPrefix: /var/lib/kubelet
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:allow-csi-driver
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - allow-csi-driver
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default:allow-csi-driver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:allow-csi-driver
+subjects:
+- kind: ServiceAccount
+  name: secrets-store-csi-driver
+  namespace: default
+- kind: ServiceAccount
+  name: csi-secrets-store-provider-azure
+  namespace: default
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: allow-csi-driver-provider-azure
+spec:
+  seLinux:
+    rule: RunAsAny
+  volumes:
+  - hostPath
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  allowedHostPaths:
+    - pathPrefix: /etc/kubernetes/secrets-store-csi-providers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:allow-csi-driver-provider-azure
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - allow-csi-driver-provider-azure
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default:allow-csi-driver-provider-azure
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:allow-csi-driver-provider-azure
+subjects:
+- kind: ServiceAccount
+  name: csi-secrets-store-provider-azure
+  namespace: default

--- a/manifest_staging/deployment/provider-azure-installer-windows.yaml
+++ b/manifest_staging/deployment/provider-azure-installer-windows.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-azure
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: csi-secrets-store-provider-azure
+  name: csi-secrets-store-provider-azure-windows
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-azure
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-azure
+    spec:
+      serviceAccountName: csi-secrets-store-provider-azure
+      containers:
+        - name: provider-azure-installer
+          image: mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.8
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+            limits:
+              cpu: 100m
+              memory: 200Mi
+          env:
+            - name: TARGET_DIR
+              value: "C:\\k\\secrets-store-csi-providers"
+          volumeMounts:
+            - mountPath: "C:\\k\\secrets-store-csi-providers"
+              name: providervol
+      volumes:
+        - name: providervol
+          hostPath:
+            path: "C:\\k\\secrets-store-csi-providers"
+            type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: windows

--- a/manifest_staging/deployment/provider-azure-installer.yaml
+++ b/manifest_staging/deployment/provider-azure-installer.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-azure
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: csi-secrets-store-provider-azure
+  name: csi-secrets-store-provider-azure
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-azure
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-azure
+    spec:
+      serviceAccountName: csi-secrets-store-provider-azure
+      containers:
+        - name: provider-azure-installer
+          image: mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.8
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: TARGET_DIR
+              value: "/etc/kubernetes/secrets-store-csi-providers"
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+      volumes:
+        - name: providervol
+          hostPath:
+            path: "/etc/kubernetes/secrets-store-csi-providers"
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -61,7 +61,7 @@ setup() {
 }
 
 @test "install driver helm chart" {
-  run helm install csi charts/csi-secrets-store-provider-azure --namespace dev --set windows.enabled=true \
+  run helm install csi manifest_staging/charts/csi-secrets-store-provider-azure --namespace dev --set windows.enabled=true \
       --set secrets-store-csi-driver.windows.enabled=true \
       --set image.repository=${PROVIDER_TEST_IMAGE} \
       --set image.tag=${IMAGE_TAG} \


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds a new `manifest_staging` dir to hold the latest helm charts and deployment manifests. These manifests are moved over to the official `deployment` and `charts` dir at the time of the release. 

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Special Notes for Reviewers**: