### PR TITLE
fix: custom azure environment not supported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ e2e-test:
 .PHONY: setup-kind
 setup-kind:
 	curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output kind && chmod +x kind && sudo mv kind /usr/local/bin/
-	kind create cluster --image kindest/node:v${KIND_K8S_VERSION}
+	kind create cluster --image kindest/node:v${KIND_K8S_VERSION} --config test/kind-config.yaml
 
 .PHONY: install-helm
 install-helm:
@@ -112,6 +112,10 @@ install-helm:
 
 .PHONY: e2e-local-bootstrap
 e2e-local-bootstrap:
-	kind create cluster --image kindest/node:v${KIND_K8S_VERSION}
+	kind create cluster --image kindest/node:v${KIND_K8S_VERSION} --config test/kind-config.yaml
 	make image
 	kind load docker-image --name kind $(DOCKER_IMAGE):$(IMAGE_VERSION)
+
+.PHONY: e2e-kind-cleanup
+e2e-kind-cleanup:
+	kind delete cluster --name kind

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Azure Key Vault provider for [Secrets Store CSI driver](https://github.com/kuber
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
 - [Testing](#testing)
+- [Other Azure Clouds](#other-azure-clouds)
 - [Support](#support)
 
 ## Demo
@@ -124,8 +125,8 @@ To provide identity to access key vault, refer to the following [section](#provi
   | useVMManagedIdentity   | no       | [__*available for version > 0.0.4*__] specify access mode to enable use of VM's managed identity                                                                                                                | "false"       |
   | userAssignedIdentityID | no       | [__*available for version > 0.0.4*__] the user assigned identity ID is required for VMSS User Assigned Managed Identity mode                                                                                    | ""            |
   | keyvaultName           | yes      | name of a Key Vault instance                                                                                                                                                                                    | ""            |
-  | cloudName              | no       | [__*available for version > 0.0.4*__] name of the azure cloud based on azure go sdk (AzurePublicCloud,AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud)                                                | ""            |
-  | cloudEnvFileName       | no       | [__*available for version > 0.0.7*__] path to the file to be used while populating the Azure Environment                                                                                                        | ""            |
+  | cloudName              | no       | [__*available for version > 0.0.4*__] name of the azure cloud based on azure go sdk (AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud, AzureStackCloud)                              | ""            |
+  | cloudEnvFileName       | no       | [__*available for version > 0.0.7*__] path to the file to be used while populating the Azure Environment (required if target cloud is AzureStackCloud). More details [here](#other-azure-clouds).               | ""            |
   | objects                | yes      | a string of arrays of strings                                                                                                                                                                                   | ""            |
   | objectName             | yes      | name of a Key Vault object                                                                                                                                                                                      | ""            |
   | objectAlias            | no       | [__*available for version > 0.0.4*__] specify the filename of the object when written to disk - defaults to objectName if not provided                                                                          | ""            |
@@ -259,6 +260,11 @@ Please refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for more information.
 ## Testing
 
 For documentation on how to locally test the Secrets Store CSI Driver Provider for Azure, please refer to [this guide](docs/testing.md)
+
+## Other Azure Clouds
+
+For documentation on how to pull secret content from air-gapped and/or on-prem clouds (such as Azure Stack Hub),
+please refer to [this guide](docs/custom-environments.md).
 
 ## Support
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,3 +73,59 @@ jobs:
       SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
       TENANT_ID: $(TENANT_ID)
       CI_KIND_CLUSTER: true
+  - script: |
+      make e2e-kind-cleanup
+    displayName: 'Delete kind cluster'
+
+- job: custom_cloud_e2e_test_kind
+  pool:
+    vmImage: 'ubuntu-latest'
+  timeoutInMinutes: 10
+  cancelTimeoutInMinutes: 5
+  workspace:
+    clean: all
+
+  variables:
+    GOPATH: '$(system.defaultWorkingDirectory)/gopath'
+    modulePath: '$(GOPATH)/src/github.com/$(build.repository.name)'
+
+  steps:
+  - task: GoTool@0
+    inputs:
+      version: '1.14.1'
+  - script: |
+      sudo add-apt-repository ppa:rmescandon/yq && sudo apt-get -o Acquire::Retries=30 update && sudo apt-get install yq
+      sudo apt-get -o Acquire::Retries=30 update && sudo apt-get -o Acquire::Retries=30 install -y bats
+      bats --version
+    displayName: 'Set up workspace and install dependencies'
+  - script: |
+      # Generate image version
+      IMAGE_VERSION=linux-e2e-$(git rev-parse --short HEAD)
+      echo "Image version: ${IMAGE_VERSION}"
+
+      export IMAGE_VERSION="${IMAGE_VERSION}"
+      export IMAGE_TAG="${IMAGE_VERSION}"
+      echo "##vso[task.setvariable variable=IMAGE_VERSION]${IMAGE_VERSION}"
+      echo "##vso[task.setvariable variable=IMAGE_TAG]${IMAGE_VERSION}"
+      
+      make e2e-bootstrap
+      export KUBECONFIG=$(kind get kubeconfig-path)
+      kubectl create ns dev
+      make e2e-test
+    displayName: "Run custom cloud e2e tests on kind cluster"
+    env:
+      AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+      AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+      KEY_NAME: $(KEY_NAME)
+      KEY_VERSION: $(KEY_VERSION)
+      KEYVAULT_NAME: $(KEYVAULT_NAME)
+      RESOURCE_GROUP: $(RESOURCE_GROUP)
+      SECRET_NAME: $(SECRET_NAME)
+      SUBSCRIPTION_ID: $(SUBSCRIPTION_ID)
+      TENANT_ID: $(TENANT_ID)
+      CI_KIND_CLUSTER: true
+      AZURE_ENVIRONMENT: AzureStackCloud
+      AZURE_ENVIRONMENT_FILEPATH: /etc/kubernetes/secrets-store-csi-providers/custom_environment.json
+  - script: |
+      make e2e-kind-cleanup
+    displayName: 'Delete kind cluster'

--- a/docs/custom-environments.md
+++ b/docs/custom-environments.md
@@ -1,0 +1,32 @@
+# Custom Azure Environments
+
+In order to pull secret content from Key Vault instances hosted on air-gapped and/or on-prem Azure clouds,
+your `SecretProviderClass` resource must include the following:
+
+```yaml
+parameters:
+  cloudName: "AzureStackCloud"
+  cloudEnvFileName: "/path/to/custom/environment.json
+```
+
+Parameter `cloudEnvFileName` should be the path to a JSON file that contains the custom cloud environment details that
+[azure-sdk-for-go](https://github.com/Azure/azure-sdk-for-go) needs to interact with the target Key Vault instance.
+
+Typically, the custom cloud environment file is stored in the file system of the Kubernetes node
+and accessible to the `secrets-store-csi-driver` pods through a mounted volume.
+
+Even if the target cloud is not an Azure Stack Hub cloud, cloud name must be set to `"AzureStackCloud"`
+to signal `azure-sdk-for-go` to load the custom cloud environment details from `cloudEnvFileName`.
+
+## Environment files
+
+The custom cloud environment sample below shows the minimum set of properties required by `secrets-store-csi-driver-provider-azure`.
+
+```json
+{
+  "name": "AzureStackCloud",
+  "activeDirectoryEndpoint": "https://login.microsoftonline.com/",
+  "keyVaultEndpoint": "https://vault.azure.net/",
+  "keyVaultDNSSuffix": "vault.azure.net"
+}
+```

--- a/pkg/azure/provider.go
+++ b/pkg/azure/provider.go
@@ -328,13 +328,13 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 		return fmt.Errorf("tenantId is not set")
 	}
 
-	azureCloudEnv, err := ParseAzureEnvironment(cloudName)
-	if err != nil {
-		return fmt.Errorf("cloudName %s is not valid, error: %v", cloudName, err)
-	}
 	err = setAzureEnvironmentFilePath(cloudEnvFileName)
 	if err != nil {
 		return fmt.Errorf("failed to set AZURE_ENVIRONMENT_FILEPATH env to %s, error %+v", cloudEnvFileName, err)
+	}
+	azureCloudEnv, err := ParseAzureEnvironment(cloudName)
+	if err != nil {
+		return fmt.Errorf("cloudName %s is not valid, error: %v", cloudName, err)
 	}
 
 	usePodIdentity := false

--- a/pkg/azure/provider_test.go
+++ b/pkg/azure/provider_test.go
@@ -258,7 +258,7 @@ func TestParseAzureEnvironmentAzureStackCloud(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error to be nil, got: %+v", err)
 	}
-	_, err = io.WriteString(file, `{}`)
+	_, err = io.WriteString(file, fmt.Sprintf(`{"name": "%s"}`, azureStackCloudEnvName))
 	if err != nil {
 		t.Fatalf("expected error to be nil, got: %+v", err)
 	}
@@ -272,9 +272,12 @@ func TestParseAzureEnvironmentAzureStackCloud(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error to be nil, got: %+v", err)
 	}
-	_, err = ParseAzureEnvironment(azureStackCloudEnvName)
+	env, err := ParseAzureEnvironment(azureStackCloudEnvName)
 	if err != nil {
 		t.Fatalf("expected error to be nil, got: %+v", err)
+	}
+	if env.Name != azureStackCloudEnvName {
+		t.Fatalf("expected environment name to be '%s', got: '%s'", azureStackCloudEnvName, env.Name)
 	}
 }
 

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -7,6 +7,8 @@ WAIT_TIME=60
 SLEEP_TIME=1
 IMAGE_TAG=${IMAGE_TAG:-e2e-$(git rev-parse --short HEAD)}
 PROVIDER_TEST_IMAGE=${PROVIDER_TEST_IMAGE:-"upstreamk8sci.azurecr.io/public/k8s/csi/secrets-store/provider-azure"}
+AZURE_ENVIRONMENT=${AZURE_ENVIRONMENT:-"AzurePublicCloud"}
+AZURE_ENVIRONMENT_FILEPATH=${AZURE_ENVIRONMENT_FILEPATH:-""}
 NODE_SELECTOR_OS=linux
 BASE64_FLAGS="-w 0"
 if [[ "$OSTYPE" == *"darwin"* ]]; then

--- a/test/bats/tests/azure_v1alpha1_secretproviderclass.yaml
+++ b/test/bats/tests/azure_v1alpha1_secretproviderclass.yaml
@@ -9,6 +9,8 @@ spec:
     useVMManagedIdentity: "false"    # [OPTIONAL available for version > 0.0.4] if not provided, will default to "false"
     userAssignedIdentityID: ""     # [OPTIONAL available for version > 0.0.4] use the client id to specify which user assigned managed identity to use. If using a user assigned identity as the VM's managed identity, then specify the identity's client id. If empty, then defaults to use the system assigned identity on the VM
     keyvaultName: "$KEYVAULT_NAME" # the name of the KeyVault
+    cloudName: "$AZURE_ENVIRONMENT"
+    cloudEnvFileName: "$AZURE_ENVIRONMENT_FILEPATH"
     objects: |
       array:
         - |

--- a/test/custom_environment.json
+++ b/test/custom_environment.json
@@ -1,0 +1,6 @@
+{
+    "name": "AzureStackCloud",
+    "activeDirectoryEndpoint": "https://login.microsoftonline.com/",
+    "keyVaultEndpoint": "https://vault.azure.net/",
+    "keyVaultDNSSuffix": "vault.azure.net"
+}

--- a/test/e2e/cluster_configs/linux-custom-cloud.json
+++ b/test/e2e/cluster_configs/linux-custom-cloud.json
@@ -1,0 +1,82 @@
+{
+    "apiVersion": "vlabs",
+    "properties": {
+        "orchestratorProfile": {
+            "orchestratorType": "Kubernetes",
+            "orchestratorRelease": "$AKSENGINE_K8S_VERSION",
+            "kubernetesConfig": {
+                "loadBalancerSku": "Standard",
+                "excludeMasterFromStandardLB": true,
+                "addons": [
+                    {
+                        "name": "csi-secrets-store",
+                        "enabled": false
+                    }
+                ]
+            }
+        },
+        "customCloudProfile": {
+            "portalURL": "https://portal.$AZURE_LOCATION.azure.com/",
+            "identitySystem": "azure_ad",
+            "environment": {
+                "name": "AzureStackCloud",
+                "managementPortalURL": "https://manage.windowsazure.com/",
+                "publishSettingsURL": "https://manage.windowsazure.com/publishsettings/index",
+                "serviceManagementEndpoint": "https://management.core.windows.net/",
+                "resourceManagerEndpoint": "https://management.azure.com/",
+                "activeDirectoryEndpoint": "https://login.microsoftonline.com/",
+                "galleryEndpoint": "https://gallery.azure.com/",
+                "keyVaultEndpoint": "https://vault.azure.net/",
+                "graphEndpoint": "https://graph.windows.net/",
+                "serviceBusEndpoint": "https://servicebus.windows.net/",
+                "batchManagementEndpoint": "https://batch.core.windows.net/",
+                "storageEndpointSuffix": "core.windows.net",
+                "sqlDatabaseDNSSuffix": "database.windows.net",
+                "trafficManagerDNSSuffix": "trafficmanager.net",
+                "keyVaultDNSSuffix": "vault.azure.net",
+                "serviceBusEndpointSuffix": "servicebus.windows.net",
+                "serviceManagementVMDNSSuffix": "cloudapp.net",
+                "resourceManagerVMDNSSuffix": "cloudapp.azure.com",
+                "containerRegistryDNSSuffix": "azurecr.io",
+                "cosmosDBDNSSuffix": "documents.azure.com",
+                "tokenAudience": "https://management.azure.com/",
+                "resourceIdentifiers": {
+                    "graph": "https://graph.windows.net/",
+                    "keyVault": "https://vault.azure.net",
+                    "datalake": "https://datalake.azure.net/",
+                    "batch": "https://batch.core.windows.net/",
+                    "operationalInsights": "https://api.loganalytics.io",
+                    "storage": "https://storage.azure.com/"
+                }
+            }
+        },
+        "masterProfile": {
+            "count": $MASTER_COUNT,
+            "dnsPrefix": "$AZURE_CLUSTER_NAME",
+            "vmSize": "Standard_D2_v3"
+        },
+        "agentPoolProfiles": [
+            {
+                "name": "agentpool1",
+                "count": $AGENT_COUNT,
+                "vmSize": "Standard_D2_v3",
+                "availabilityProfile": "VirtualMachineScaleSets"
+            }
+        ],
+        "linuxProfile": {
+            "adminUsername": "$AZURE_ADMIN_USERNAME",
+            "ssh": {
+                "publicKeys": [
+                    {
+                        "keyData": "$AZURE_SSH_KEY"
+                    }
+                ]
+            }
+        },
+        "servicePrincipalProfile": {
+            "clientId": "$CLIENT_ID",
+            "secret": "$CLIENT_SECRET"
+        }
+    }
+}
+

--- a/test/kind-config.yaml
+++ b/test/kind-config.yaml
@@ -1,0 +1,10 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  # Load environment json into kind node to enable custom cloud coverage
+  - containerPath: /etc/kubernetes/secrets-store-csi-providers/custom_environment.json
+    hostPath: test/custom_environment.json
+    readOnly: true
+    propagation: None


### PR DESCRIPTION
**Reason for Change**:

Provider fails with error `cloudName is not valid` if `cloudName: "AzureStackCloud"`.

Flipping the execution order of functions `setAzureEnvironmentFilePath` and `ParseAzureEnvironment` solves the problem.

I noticed that the custom cloud scenario is not covered by the e2e suite so I added a few extra modifications to add coverage at least if running locally.

Marked as `work-in-progress` because there a few things we could possibly add to this PR (or a subsequent one):
1. Custom cloud coverage in CI pipeline
1. Document minimum required `environment.json`
1. Add extra mount to `provider-azure-installer.yaml` for the custom environment file 

Please let me know how you want to scope this PR.

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:

Related to #153

**Please answer the following questions with yes/no**:

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? no

**Special Notes for Reviewers**: