### PR TITLE
Fix missing link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Create a `SecretProviderClass` custom resource to provide provider-specific para
 
 > NOTE: The `SecretProviderClass` has to be in the same namespace as the pod referencing it.
 
-Update [this sample deployment](examples/v1alpha1_secretproviderclass.yaml) to create a `SecretProviderClass` resource to provide Azure-specific parameters for the Secrets Store CSI driver.
+Update [this sample deployment](examples/v1alpha1_secretproviderclass_service_principal.yaml) to create a `SecretProviderClass` resource to provide Azure-specific parameters for the Secrets Store CSI driver.
 
 To provide identity to access key vault, refer to the following [section](#provide-identity-to-access-key-vault).
 


### PR DESCRIPTION
**Reason for Change**:
The doc hasn't updated during renaming the file in https://github.com/Azure/secrets-store-csi-driver-provider-azure/commit/a4da7f93d13f67e6625d858eb4816496787eeecd#diff-f8e840de9d1a8ad74c96e6e08a892b45


**Requirements**

- [x] squashed commits
- [x] included documentation
~~- [ ] added unit tests and e2e tests (if applicable).~~


**Issue Fixed**:
n/a

**Please answer the following questions with yes/no**:

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
  - no (Not contain code from nor inspired by another project)

**Special Notes for Reviewers**: