### PR TITLE
docs: add upgrade doc for 0.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ Here is a sample [deployment yaml](https://github.com/kubernetes-sigs/secrets-st
 
 ## Troubleshooting
 
+### For Azure Key Vault Provider version < `0.0.9`
+
 To troubleshoot issues with the csi driver and the provider, you can look at logs from the `secrets-store` container of the csi driver pod running on the same node as your application pod:
 
   ```bash
@@ -251,6 +253,17 @@ To troubleshoot issues with the csi driver and the provider, you can look at log
   # find the secrets store csi driver pod running on the same node as your application pod
 
   kubectl logs csi-secrets-store-secrets-store-csi-driver-7x44t secrets-store
+  ```
+
+### For Azure Key Vault Provider version `0.0.9+`
+
+For `0.0.9+` the provider logs are available in the provider pods. To troubleshoot issues with the provider, you can look at logs from the provider pod running on the same node as your application pod
+
+  ```bash
+  kubectl get pod -o wide
+  # find the csi-secrets-store-provider-azure pod running on the same node as your application pod
+
+  kubectl logs csi-csi-secrets-store-provider-azure-lmx6p
   ```
 
 ## Contributing

--- a/docs/how-to-upgrade.md
+++ b/docs/how-to-upgrade.md
@@ -1,0 +1,53 @@
+# Upgrade notes
+
+This document highlights the required actions for upgrading to the latest release.
+
+## Upgrading to Key Vault provider 0.0.9+
+
+**tl;dr** - :warning: `0.0.9+` release of the Azure Key Vault provider is incompatible with the Secrets Store CSI Driver versions < `v0.0.14`.
+
+Prior to `v0.0.14` release of the Secrets Store CSI Driver, the driver communicated with the provider by invoking the provider binary installed on the host. However with `v0.0.14` the driver now introduces a new option to communicate with the provider using gRPC. This feature is enabled by a feature flag in the driver `--grpc-supported-providers=azure`. The `0.0.9` release of the Azure Key Vault provider implements the gRPC server changes and is no longer backward compatible with the Secrets Store CSI Driver versions < `v0.0.14`.
+
+Please carefully read this doc as you upgrade to the latest release of the Azure Key Vault Provider
+
+
+### If the Secrets Store CSI Driver and Azure Key Vault Provider were installed using helm charts from this [repo](../charts/csi-secrets-store-provider-azure/README.md)
+
+`helm upgrade` to the latest chart release in the repo will update the Azure Key Vault Provider and Secrets Store CSI Driver to the compatible versions
+
+- This updates the driver version to `v0.0.14+`
+- This updates the provider version to `0.0.9+`
+- This updates the driver manifest to include the flag `--grpc-supported-providers=azure` to enable communication between driver and provider using gRPC
+
+Run the following commands to confirm the images have been updated -
+
+1. secrets-store container in secrets-store-csi-driver pod is running v0.0.14+
+
+```bash
+➜ kubectl get ds -l app=secrets-store-csi-driver -o jsonpath='{range .items[*]}{.spec.template.spec.containers[1].image}{"\n"}'
+mcr.microsoft.com/k8s/csi/secrets-store/driver:v0.0.14
+```
+
+2. secrets-store container in the secrets-store-csi-driver pod contains the arg `--grpc-supported-providers=azure`
+
+```bash
+➜ kubectl get ds -l app=secrets-store-csi-driver -o jsonpath='{range .items[*]}{.spec.template.spec.containers[1].args}{"\n"}'
+["--debug=true","--endpoint=$(CSI_ENDPOINT)","--nodeid=$(KUBE_NODE_NAME)","--provider-volume=/etc/kubernetes/secrets-store-csi-providers","--grpc-supported-providers=azure","--metrics-addr=:8080"]
+```
+
+3. csi-secrets-store-provider-azure pod is running `0.0.9+`
+
+```bash
+➜ kubectl get ds -l app=csi-secrets-store-provider-azure -o jsonpath='{range .items[*]}{.spec.template.spec.containers[0].image}{"\n"}'
+mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.9
+```
+
+### If the Secrets Store CSI Driver and Azure Key Vault Provider were installed using [deployment yamls](install-yamls.md)
+
+The driver and provider need to be updated one after the other to ensure compatible versions are being run.
+
+- Update the driver by installing the yamls from [Install the Secrets Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver#install-the-secrets-store-csi-driver)
+  - **ACTION REQUIRED** If using the yamls from the Secrets Store CSI Driver, add the following flag `--grpc-supported-providers=azure` to the [Linux](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/deploy/secrets-store-csi-driver.yaml) and [Windows](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/deploy/secrets-store-csi-driver-windows.yaml) daemonset manifests.
+    - The flag needs to be added to the secrets-store container args
+  - **ACTION REQUIRED** If using the helm charts from secrets-store-csi-driver, then run `helm upgrade` with `--set grpcSupportedProviders=azure`
+- After the driver is upgraded to the latest version install the latest Azure Key Vault provider by following the [doc](install-yamls.md)

--- a/docs/how-to-upgrade.md
+++ b/docs/how-to-upgrade.md
@@ -39,15 +39,15 @@ mcr.microsoft.com/k8s/csi/secrets-store/driver:v0.0.14
 
 ```bash
 ➜ kubectl get ds -l app=csi-secrets-store-provider-azure -o jsonpath='{range .items[*]}{.spec.template.spec.containers[0].image}{"\n"}'
-mcr.microsoft.com/k8s/csi/secrets-store/provider-azure:0.0.9
+mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.9
 ```
 
 ### If the Secrets Store CSI Driver and Azure Key Vault Provider were installed using [deployment yamls](install-yamls.md)
 
 The driver and provider need to be updated one after the other to ensure compatible versions are being run.
 
-- Update the driver by installing the yamls from [Install the Secrets Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver#install-the-secrets-store-csi-driver)
-  - **ACTION REQUIRED** If using the yamls from the Secrets Store CSI Driver, add the following flag `--grpc-supported-providers=azure` to the [Linux](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/deploy/secrets-store-csi-driver.yaml) and [Windows](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/deploy/secrets-store-csi-driver-windows.yaml) daemonset manifests.
-    - The flag needs to be added to the secrets-store container args
-  - **ACTION REQUIRED** If using the helm charts from secrets-store-csi-driver, then run `helm upgrade` with `--set grpcSupportedProviders=azure`
-- After the driver is upgraded to the latest version install the latest Azure Key Vault provider by following the [doc](install-yamls.md)
+1. Update the driver by installing the yamls from [Install the Secrets Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver#install-the-secrets-store-csi-driver)
+     - **ACTION REQUIRED** If using the yamls from the Secrets Store CSI Driver, add the following flag `--grpc-supported-providers=azure` to the [Linux](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/deploy/secrets-store-csi-driver.yaml) and [Windows](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/deploy/secrets-store-csi-driver-windows.yaml) daemonset manifests.
+       - The flag needs to be added to the secrets-store container args
+     - **ACTION REQUIRED** If using the helm charts from secrets-store-csi-driver, then run `helm upgrade` with `--set grpcSupportedProviders=azure`
+2. After the driver is upgraded to the latest version install the latest Azure Key Vault provider by following the [doc](install-yamls.md)

--- a/docs/install-yamls.md
+++ b/docs/install-yamls.md
@@ -11,7 +11,10 @@ Quick start instructions for the setup and configuration of secrets-store-csi-dr
 
 💡 Follow the [Installation guide for the Secrets Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver#usage) to install the driver.
 
-To validate the driver is running as expected, run the following commands:
+> **NOTE:** `0.0.9+` release of the Azure Key Vault provider is incompatible with the Secrets Store CSI Driver versions < `v0.0.14`. While installing the Secrets Store CSI Driver using yamls, add the following flag `--grpc-supported-providers=azure` to the [Linux](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/deploy/secrets-store-csi-driver.yaml) and [Windows](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/deploy/secrets-store-csi-driver-windows.yaml) daemonset manifests.
+> - The flag needs to be added to the `secrets-store` container args
+
+To validate the driver is running as expected, run the following command:
 
 ```bash
 kubectl get pods -l app=csi-secrets-store
@@ -23,6 +26,17 @@ You should see the driver pods running on each agent node:
 NAME                                     READY   STATUS    RESTARTS   AGE
 csi-secrets-store-jlls6                  1/1     Running   0          10s
 csi-secrets-store-qt2l7                  1/1     Running   0          10s
+```
+
+To validate the `--grpc-supported-providers=azure` arg has been configured correctly, run the following command:
+
+```bash
+kubectl get ds -l app=csi-secrets-store -o jsonpath='{range .items[*]}{.spec.template.spec.containers[1].args}{"\n"}'
+```
+
+You should see the args for the `secrets-store` container in the driver pods for each node:
+```bash
+["--debug=true","--endpoint=$(CSI_ENDPOINT)","--nodeid=$(KUBE_NODE_NAME)","--provider-volume=/etc/kubernetes/secrets-store-csi-providers","--grpc-supported-providers=azure","--metrics-addr=:8080"]
 ```
 
 ### Install the Azure Key Vault Provider


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
The upcoming release `0.0.9` for Azure Key Vault Provider is incompatible with Secrets Store CSI Driver versions < `v0.0.14`.
- The driver is packaged as dependency in the provider helm charts and users running `helm upgrade` from the charts repo don't require any manual actions.
- The doc details steps users need to take for manual upgrade scenario

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Special Notes for Reviewers**: