### PR TITLE
chore: bump version to 0.0.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export $(shell test -f secrets.env && sed 's/=.*//' secrets.env)
 REGISTRY_NAME ?= upstreamk8sci
 REGISTRY ?= $(REGISTRY_NAME).azurecr.io
 DOCKER_IMAGE ?= $(REGISTRY)/public/k8s/csi/secrets-store/provider-azure
-IMAGE_VERSION ?= 0.0.8
+IMAGE_VERSION ?= 0.0.9
 IMAGE_NAME ?= secrets-store-csi-driver-provider-azure
 
 BUILD_DATE=$$(date +%Y-%m-%d-%H:%M)


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Bumps version to `0.0.9` preparing for next release

depends on #246 to be merged first

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Special Notes for Reviewers**: