### PR TITLE
feat: add validation for file name

### DIFF
--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -514,3 +514,46 @@ func TestFormatKeyVaultObject(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateFilePath(t *testing.T) {
+	cases := []struct {
+		desc        string
+		fileName    string
+		expectedErr error
+	}{
+		{
+			desc:        "file name is absolute path",
+			fileName:    "/secret1",
+			expectedErr: fmt.Errorf("file name must be a relative path"),
+		},
+		{
+			desc:        "file name contains '..'",
+			fileName:    "secret1/..",
+			expectedErr: fmt.Errorf("file name must not contain '..'"),
+		},
+		{
+			desc:        "file name starts with '..'",
+			fileName:    "../secret1",
+			expectedErr: fmt.Errorf("file name must not contain '..'"),
+		},
+		{
+			desc:        "file name is empty",
+			fileName:    "",
+			expectedErr: fmt.Errorf("file name must not be empty"),
+		},
+		{
+			desc:        "valid file name",
+			fileName:    "secret1",
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := validateFileName(tc.fileName)
+			if tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() || tc.expectedErr == nil && err != nil {
+				t.Fatalf("expected err: %+v, got: %+v", tc.expectedErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Add validation for file name

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

Yes

Implementation based on reference from:
- [validateLocalDescendingPath] https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/validation.go#L1158-L1170
- [validatePathNoBacksteps] https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/validation.go#L1172-L1186

**Special Notes for Reviewers**: