### PR TITLE
feat: add pprof profiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ IMAGE_VERSION ?= 0.0.10
 IMAGE_NAME ?= secrets-store-csi-driver-provider-azure
 
 BUILD_DATE=$$(date +%Y-%m-%d-%H:%M)
+BUILD_COMMIT := $$(git rev-parse --short HEAD)
 GO_FILES=$(shell go list ./...)
 ORG_PATH=github.com/Azure
 REPO_PATH="$(ORG_PATH)/$(IMAGE_NAME)"
@@ -15,12 +16,13 @@ E2E_IMAGE_TAG=$(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)
 
 BUILD_DATE_VAR := $(REPO_PATH)/pkg/version.BuildDate
 BUILD_VERSION_VAR := $(REPO_PATH)/pkg/version.BuildVersion
+VCS_VAR := $(REPO_PATH)/pkg/version.Vcs
 
 ALL_DOCS := $(shell find . -name '*.md' -type f | sort)
 TOOLS_MOD_DIR := ./tools
 TOOLS_DIR := $(abspath ./.tools)
 
-LDFLAGS ?= "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(IMAGE_VERSION)"
+LDFLAGS ?= "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(IMAGE_VERSION) -X $(VCS_VAR)=$(BUILD_COMMIT)"
 
 GO111MODULE ?= on
 export GO111MODULE

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 )
 
 var (
@@ -10,6 +11,8 @@ var (
 	BuildDate string
 	// BuildVersion is the version of binary
 	BuildVersion string
+	// Vcs is is the commit hash for the binary build
+	Vcs string
 
 	minDriverVersion = "v0.0.8"
 )
@@ -40,5 +43,5 @@ func PrintVersion() (err error) {
 
 // GetUserAgent returns UserAgent string to append to the agent identifier.
 func GetUserAgent() string {
-	return fmt.Sprintf("csi-secrets-store/%s", BuildVersion)
+	return fmt.Sprintf("csi-secrets-store/%s (%s/%s) %s/%s", BuildVersion, runtime.GOOS, runtime.GOARCH, Vcs, BuildDate)
 }


### PR DESCRIPTION
Enables profiling using pprof and also logs the current AKV provider
version at startup.

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds pprof profiling
- Adds logs for current AKV provider version during startup

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? **No**


**Special Notes for Reviewers**: