### PR TITLE
fix: switch to using flag instead of pflag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"net"
 	"net/http"
@@ -15,7 +16,6 @@ import (
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/version"
 
 	"github.com/Azure/go-autorest/autorest/adal"
-	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	json "k8s.io/component-base/logs/json"
 	"k8s.io/klog/v2"
@@ -23,18 +23,18 @@ import (
 )
 
 var (
-	versionInfo   = pflag.Bool("version", false, "prints the version information")
-	endpoint      = pflag.String("endpoint", "unix:///tmp/azure.sock", "CSI gRPC endpoint")
-	logFormatJSON = pflag.Bool("log-format-json", false, "set log formatter to json")
-	enableProfile = pflag.Bool("enable-pprof", false, "enable pprof profiling")
-	profilePort   = pflag.Int("pprof-port", 6060, "port for pprof profiling")
+	versionInfo   = flag.Bool("version", false, "prints the version information")
+	endpoint      = flag.String("endpoint", "unix:///tmp/azure.sock", "CSI gRPC endpoint")
+	logFormatJSON = flag.Bool("log-format-json", false, "set log formatter to json")
+	enableProfile = flag.Bool("enable-pprof", false, "enable pprof profiling")
+	profilePort   = flag.Int("pprof-port", 6060, "port for pprof profiling")
 )
 
 func main() {
 	klog.InitFlags(nil)
 	defer klog.Flush()
 
-	pflag.Parse()
+	flag.Parse()
 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGTERM, syscall.SIGINT, os.Interrupt)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/kubernetes-csi/csi-lib-utils v0.7.0
 	github.com/pkg/errors v0.9.1
-	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	google.golang.org/grpc v1.31.0

--- a/test/bats/azure.bats
+++ b/test/bats/azure.bats
@@ -74,6 +74,7 @@ setup() {
       --set image.pullPolicy="IfNotPresent" \
       --set secrets-store-csi-driver.enableSecretRotation=true \
       --set secrets-store-csi-driver.rotationPollInterval=30s \
+      --set logVerbosity=2 \
       --dependency-update
 
   assert_success


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Switches to using `flag` instead of `pflag`

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #330 

**Please answer the following questions with yes/no**:

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Special Notes for Reviewers**: