### PR TITLE
fix: windows image build with buildx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,10 @@ endif
 .PHONY: e2e-container
 e2e-container: build build-windows
 	docker buildx rm container-builder || true
-	docker buildx create --use --name=container-builder
+	# only moby/buildkit:foreign-mediatype works on building Windows image now
+	# https://github.com/moby/buildkit/pull/1879
+	# Github issue: https://github.com/moby/buildkit/issues/1877
+	docker buildx create --use --name=container-builder --driver-opt image=moby/buildkit:v0.7.2
 ifdef CI_KIND_CLUSTER
 		DOCKER_IMAGE=$(REGISTRY)/$(IMAGE_NAME) make image
 		kind load docker-image --name kind $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
This is a workaround until the bug is fixed in buildkit: https://github.com/moby/buildkit/pull/1879

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Please answer the following questions with yes/no**:

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Special Notes for Reviewers**: