### PR TITLE
feat: add grpc health probe for linux daemonset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN chmod a+x /bin/secrets-store-csi-driver-provider-azure
 # upgrading apt &libapt-pkg5.0 due to CVE-2020-27350
 # upgrading libp11-kit0 due to CVE-2020-29362, CVE-2020-29363 and CVE-2020-29361
 RUN apt-mark unhold apt && \
-    clean-install ca-certificates cifs-utils mount apt libapt-pkg5.0 libp11-kit0 
+    clean-install ca-certificates cifs-utils mount apt libapt-pkg5.0 libp11-kit0 wget
+RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe
 
 ENTRYPOINT ["/bin/secrets-store-csi-driver-provider-azure"]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/adal"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	json "k8s.io/component-base/logs/json"
 	"k8s.io/klog/v2"
 	k8spb "sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
@@ -87,6 +88,8 @@ func main() {
 	}
 	s := grpc.NewServer(opts...)
 	k8spb.RegisterCSIDriverProviderServer(s, &server.CSIDriverProviderServer{})
+	// Register the health service.
+	grpc_health_v1.RegisterHealthServer(s, &server.CSIDriverProviderServer{})
 
 	klog.Infof("Listening for connections on address: %v", listener.Addr())
 	go s.Serve(listener)

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
@@ -38,6 +38,14 @@ spec:
               exec:
                 command:
                   - "rm /provider/azure.sock"
+          readinessProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=unix:///provider/azure.sock"]
+            initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=unix:///provider/azure.sock"]
+            initialDelaySeconds: 5
           resources:
 {{ toYaml .Values.linux.resources | indent 12 }}
           volumeMounts:

--- a/manifest_staging/deployment/provider-azure-installer.yaml
+++ b/manifest_staging/deployment/provider-azure-installer.yaml
@@ -33,6 +33,14 @@ spec:
               exec:
                 command:
                   - "rm /provider/azure.sock"
+          readinessProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=unix:///provider/azure.sock"]
+            initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=unix:///provider/azure.sock"]
+            initialDelaySeconds: 5
           resources:
             requests:
               cpu: 50m

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
@@ -63,4 +64,15 @@ func (s *CSIDriverProviderServer) Mount(ctx context.Context, req *v1alpha1.Mount
 
 func (s *CSIDriverProviderServer) Version(ctx context.Context, req *v1alpha1.VersionRequest) (*v1alpha1.VersionResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Version not implemented")
+}
+
+func (s *CSIDriverProviderServer) Check(ctx context.Context, in *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+// Watch for the serving status of the requested service.
+func (s *CSIDriverProviderServer) Watch(req *grpc_health_v1.HealthCheckRequest, w grpc_health_v1.Health_WatchServer) error {
+	return status.Error(codes.Unimplemented, "Watch is not supported")
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds grpc health probe for linux daemonset

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #310 

**Please answer the following questions with yes/no**:

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


**Special Notes for Reviewers**: