### PR TITLE
Add a note on when secrets are actually synced

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ In some cases, you may want to create a Kubernetes Secret to mirror the mounted 
 
 > NOTE: Make sure the `objectName` in `secretObjects` matches the name of the mounted content. This could be the object name or the object alias.
 
+> NOTE: The secrets will only sync once you *start a pod mounting the secret store*. Solely relying on the syncing with Kubernetes secrets feature thus does not work.
+
 A `SecretProviderClass` custom resource should have the following components:
 ```yaml
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1


### PR DESCRIPTION
This is a simple comment that emphasizes that syncing is not the primary functionality of this driver as clearly said [here](https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/230#issuecomment-691278833).

Just costed us some time to realize that, so I think it makes sense to have it directly in the documentation.