### PR TITLE
chore: update debian-base image to buster-v1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.2.0
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.3.0
 COPY ./_output/secrets-store-csi-driver-provider-azure /bin/
 RUN chmod a+x /bin/secrets-store-csi-driver-provider-azure
-# upgrading apt &libapt-pkg5.0 due to CVE-2020-27350
-# upgrading libp11-kit0 due to CVE-2020-29362, CVE-2020-29363 and CVE-2020-29361
-RUN apt-mark unhold apt && \
-    clean-install ca-certificates cifs-utils mount apt libapt-pkg5.0 libp11-kit0 wget
+RUN clean-install ca-certificates cifs-utils mount wget
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #354 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
