### PR TITLE
fix: use scheme long format for Helm dependencies

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -20,7 +20,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - //raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.17.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.17.tgz
     version: 0.0.17
   - apiVersion: v1
     appVersion: 0.0.12
@@ -41,7 +41,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - //raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.16.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.16.tgz
     version: 0.0.16
   - apiVersion: v1
     appVersion: 0.0.11


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
The short format of scheme is not available for _Helm depencendies update_ command

The `//` break the donwload link :
```
helm dependency update myHelmChart/

Getting updates for unmanaged Helm repositories...

[...]

Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading csi-secrets-store-provider-azure from repo https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/
Save error occurred:  could not download https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.17.tgz: failed to fetch https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.17.tgz : 404 Not Found
Deleting newly downloaded charts, restoring pre-update state
```

Context.
```
helm version
version.BuildInfo{Version:"v3.4.2", GitCommit:"23dd3af5e19a02d4f4baa5b2f242645a1a3af629", GitTreeState:"clean", GoVersion:"go1.14.13"}
```
```
dependencies:
- name: csi-secrets-store-provider-azure
  version: "0.0.17"
  repository: "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/"
```

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->


**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [X] No

