### PR TITLE
feat: add version response for provider

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/version"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -63,7 +64,11 @@ func (s *CSIDriverProviderServer) Mount(ctx context.Context, req *v1alpha1.Mount
 }
 
 func (s *CSIDriverProviderServer) Version(ctx context.Context, req *v1alpha1.VersionRequest) (*v1alpha1.VersionResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method Version not implemented")
+	return &v1alpha1.VersionResponse{
+		Version:        "v1alpha1",
+		RuntimeVersion: version.BuildVersion,
+		RuntimeName:    "secrets-store-csi-driver-provider-azure",
+	}, nil
 }
 
 func (s *CSIDriverProviderServer) Check(ctx context.Context, in *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/version"
 	"sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 )
 
@@ -57,8 +59,17 @@ func TestMount(t *testing.T) {
 
 func TestVersion(t *testing.T) {
 	testServer := &CSIDriverProviderServer{}
-	_, err := testServer.Version(context.TODO(), &v1alpha1.VersionRequest{})
-	if err == nil {
-		t.Fatalf("expected error to not be nil")
+	version.BuildVersion = "test"
+	resp, err := testServer.Version(context.TODO(), &v1alpha1.VersionRequest{})
+	if err != nil {
+		t.Fatalf("expected error to be nil")
+	}
+	expectedVersionResponse := &v1alpha1.VersionResponse{
+		Version:        "v1alpha1",
+		RuntimeVersion: "test",
+		RuntimeName:    "secrets-store-csi-driver-provider-azure",
+	}
+	if !reflect.DeepEqual(resp, expectedVersionResponse) {
+		t.Fatalf("expected resp: %v, got: %v", expectedVersionResponse, resp)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Sends version response back to the driver

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
