### PR TITLE
docs: add example for sync k8s secret dockerconfigjson

### DIFF
--- a/examples/sync-as-kubernetes-secret/dockerconfigjson_synck8s_v1alpha1_secretproviderclass.yaml
+++ b/examples/sync-as-kubernetes-secret/dockerconfigjson_synck8s_v1alpha1_secretproviderclass.yaml
@@ -1,0 +1,21 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: azure-docker-config
+spec:
+  provider: azure
+  secretObjects:                                # secretObjects defines the desired state of synced K8s secret objects
+    - secretName: dockerconfig
+      type: kubernetes.io/dockerconfigjson
+      data:
+        - objectName: dockerconfigjson
+          key: .dockerconfigjson
+  parameters:
+    usePodIdentity: "false"
+    keyvaultName: "kvname"                      # the name of the Keyvault
+    objects: |
+      array:
+        - |
+          objectName: dockerconfigjson
+          objectType: secret                    # Setting the objectType to secret will retrieve the certificate and private key from keyvault.
+    tenantId: "tid"                             # the tenant ID of the KeyVault

--- a/examples/sync-as-kubernetes-secret/tls_synck8s_v1alpha1_secretproviderclass.yaml
+++ b/examples/sync-as-kubernetes-secret/tls_synck8s_v1alpha1_secretproviderclass.yaml
@@ -19,5 +19,5 @@ spec:
       array:
         - |
           objectName: tls-cert
-          objectType: secret                    # Setting the objectType to secret will retrieve the certificate and private key from keyvault.
+          objectType: secret                    # Setting the objectType to secret will retrieve the certificate and private key from keyvault. Refer to https://azure.github.io/secrets-store-csi-driver-provider-azure/configurations/getting-certs-and-keys/ for more details.
     tenantId: "tid"                             # the tenant ID of the KeyVault

--- a/website/content/en/configurations/sync-with-k8-secretes.md
+++ b/website/content/en/configurations/sync-with-k8-secretes.md
@@ -99,4 +99,5 @@ spec:
 > NOTE: Here is the list of supported Kubernetes Secret types: `Opaque`, `kubernetes.io/basic-auth`, `bootstrap.kubernetes.io/token`, `kubernetes.io/dockerconfigjson`, `kubernetes.io/dockercfg`, `kubernetes.io/ssh-auth`, `kubernetes.io/service-account-token`, `kubernetes.io/tls`.  
 
 - Here is a sample [`SecretProviderClass` custom resource](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/examples/sync-as-kubernetes-secret/synck8s_v1alpha1_secretproviderclass.yaml) that syncs a secret from Azure Key Vault to a Kubernetes secret.
-- To view an example of type `kubernetes.io/tls`, refer to the [ingress-controller-tls sample](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/docs/ingress-tls.md)
+- To view an example of type `kubernetes.io/tls`, refer to the [example](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/examples/sync-as-kubernetes-secret/tls_synck8s_v1alpha1_secretproviderclass.yaml).
+- To view an example of type `kubernetes.io/dockerconfigjson`, refer to the [example](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/examples/sync-as-kubernetes-secret/dockerconfigjson_synck8s_v1alpha1_secretproviderclass.yaml) that syncs `dockerconfigjson` from Azure Key Vault to a Kubernetes secret.


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds example for syncing `dockerconfigjson` as Kubernetes secrets
- Updates example references in the docs

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/450

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
