### PR TITLE
docs: clarify sync k8s secret namespace

### DIFF
--- a/website/content/en/configurations/sync-with-k8-secretes.md
+++ b/website/content/en/configurations/sync-with-k8-secretes.md
@@ -74,12 +74,16 @@ spec:
 
 In some cases, you may want to create a Kubernetes Secret to mirror the mounted content. Use the optional `secretObjects` field to define the desired state of the synced Kubernetes secret objects.
 
-> NOTE: Make sure the `objectName` in `secretObjects` matches the file name of the mounted content. This could be the object name or the object alias.
+> NOTE: Make sure the `objectName` in `secretObjects` matches the file name of the mounted content. If object alias used, then it should be the object alias else this would be the object name.
 
-> The secrets will only sync once you *start a pod mounting the secrets*. Solely relying on the syncing with Kubernetes secrets feature thus does not work.
+{{% alert title="NOTE" color="warning" %}}
 
+- The secrets will only sync once you *start a pod mounting the secrets*. Solely relying on the syncing with Kubernetes secrets feature thus does not work.
+- The Kubernetes secrets will be synced to the same namespace as the application pod and `SecretProviderClass`.
+{{% /alert %}}
 
 A `SecretProviderClass` custom resource should have the following components:
+
 ```yaml
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds clarification about the sync k8s secret namespace

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/241

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
