### PR TITLE
feat: add support for RSA-HSM and EC-HSM keys

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -343,7 +343,7 @@ func (p *Provider) GetKeyVaultObjectContent(ctx context.Context, kvObject KeyVau
 		version := getObjectVersion(*keybundle.Key.Kid)
 		// for object type "key" the public key is written to the file in PEM format
 		switch keybundle.Key.Kty {
-		case kv.RSA:
+		case kv.RSA, kv.RSAHSM:
 			// decode the base64 bytes for n
 			nb, err := base64.RawURLEncoding.DecodeString(*keybundle.Key.N)
 			if err != nil {
@@ -370,7 +370,7 @@ func (p *Provider) GetKeyVaultObjectContent(ctx context.Context, kvObject KeyVau
 			var pemData []byte
 			pemData = append(pemData, pem.EncodeToMemory(pubKeyBlock)...)
 			return string(pemData), version, nil
-		case kv.EC:
+		case kv.EC, kv.ECHSM:
 			// decode the base64 bytes for x
 			xb, err := base64.RawURLEncoding.DecodeString(*keybundle.Key.X)
 			if err != nil {

--- a/test/e2e/framework/secretproviderclass/secretproviderclass.go
+++ b/test/e2e/framework/secretproviderclass/secretproviderclass.go
@@ -59,3 +59,20 @@ func Delete(input DeleteInput) {
 	By(fmt.Sprintf("Deleting SecretProviderClass \"%s\"", input.SecretProviderClass.Name))
 	Expect(input.Deleter.Delete(context.TODO(), input.SecretProviderClass)).Should(Succeed())
 }
+
+// UpdateInput is the input for Update.
+type UpdateInput struct {
+	Updater             framework.Updater
+	SecretProviderClass *v1alpha1.SecretProviderClass
+}
+
+// Update updates a SecretProviderClass resource.
+func Update(input UpdateInput) *v1alpha1.SecretProviderClass {
+	Expect(input.Updater).NotTo(BeNil(), "input.Updater is required for SecretProviderClass.Update")
+	Expect(input.SecretProviderClass).NotTo(BeNil(), "input.SecretProviderClass is required for SecretProviderClass.Update")
+
+	By(fmt.Sprintf("Updating SecretProviderClass \"%s/%s\"", input.SecretProviderClass.Namespace, input.SecretProviderClass.Name))
+
+	Expect(input.Updater.Update(context.TODO(), input.SecretProviderClass)).Should(Succeed())
+	return input.SecretProviderClass
+}


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds support for `RSA-HSM` and `EC-HSM` keys

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #469 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
