### PR TITLE
Update pod-security-policy.yaml to correct the unknown feild "hostPort"

### DIFF
--- a/deployment/pod-security-policy.yaml
+++ b/deployment/pod-security-policy.yaml
@@ -66,9 +66,9 @@ spec:
   - hostPath
   - secret
   hostNetwork: true
-  hostPorts:
+  hostPort:
   - min: 0
-    max: 65535
+  - max: 65535
   fsGroup:
     rule: RunAsAny
   runAsUser:

--- a/deployment/pod-security-policy.yaml
+++ b/deployment/pod-security-policy.yaml
@@ -66,9 +66,9 @@ spec:
   - hostPath
   - secret
   hostNetwork: true
-  hostPort:
+  hostPorts:
   - min: 0
-  - max: 65535
+    max: 65535
   fsGroup:
     rule: RunAsAny
   runAsUser:

--- a/manifest_staging/deployment/pod-security-policy.yaml
+++ b/manifest_staging/deployment/pod-security-policy.yaml
@@ -67,8 +67,8 @@ spec:
   - secret
   hostNetwork: true
   hostPorts:
-  - min: 0
-    max: 65535
+    - min: 0
+      max: 65535
   fsGroup:
     rule: RunAsAny
   runAsUser:

--- a/manifest_staging/deployment/pod-security-policy.yaml
+++ b/manifest_staging/deployment/pod-security-policy.yaml
@@ -66,9 +66,9 @@ spec:
   - hostPath
   - secret
   hostNetwork: true
-  hostPort:
+  hostPorts:
   - min: 0
-  - max: 65535
+    max: 65535
   fsGroup:
     rule: RunAsAny
   runAsUser:


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**: [error]error: error validating "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/deployment/pod-security-policy.yaml": error validating data: ValidationError(PodSecurityPolicy.spec): unknown field "hostPort" in io.k8s.api.policy.v1beta1.PodSecurityPolicySpec; if you choose to ignore these errors, turn validation off with --validate=false

<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?** deployment yaml update
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?** No 

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
