### PR TITLE
feat: use distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base-amd64:buster-v1.5.0
+FROM gcr.io/distroless/static:nonroot
 COPY ./_output/secrets-store-csi-driver-provider-azure /bin/
-RUN chmod a+x /bin/secrets-store-csi-driver-provider-azure
-RUN clean-install ca-certificates cifs-utils mount
 
 LABEL maintainers="aramase"
 LABEL description="Secrets Store CSI Driver Provider Azure"
 
-ENTRYPOINT ["/bin/secrets-store-csi-driver-provider-azure"]
+ENTRYPOINT ["secrets-store-csi-driver-provider-azure"]

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
@@ -66,6 +66,11 @@ spec:
           securityContext:
             privileged: true
           {{- end }}
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
             - name: provider-vol
               mountPath: /provider

--- a/manifest_staging/deployment/provider-azure-installer.yaml
+++ b/manifest_staging/deployment/provider-azure-installer.yaml
@@ -47,6 +47,11 @@ spec:
             limits:
               cpu: 50m
               memory: 100Mi
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
             - mountPath: "/provider"
               name: providervol


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
Switches to using distroless static `nonroot` base image for Linux images. As root permissions are required for binding the socket, `runAsUser: 0` is set in the securityContext.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #516 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
