### PR TITLE
chore: add unit tests and kind tests as part of nightly

### DIFF
--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -12,6 +12,13 @@ pool:
   vmImage: ubuntu-latest
 
 jobs:
+  # to get image scan results on nightly runs
+  - template: templates/unit-test.yaml
+  - template: templates/e2e-test-kind.yaml
+    parameters:
+      driverWriteSecrets:
+      - "true"
+      - "false"
   - template: templates/load-test.yaml
   - template: templates/e2e-test-azure.yaml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,5 +20,5 @@ jobs:
   - template: .pipelines/templates/e2e-test-kind.yaml
     parameters:
       driverWriteSecrets:
-        - "true"
-        - "false"
+      - "true"
+      - "false"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds unit tests as part of nightly runs so we can get image scan results
- Adds kind tests as part of nightly to test driver write secret feature periodically

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [x] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
