### PR TITLE
fix: check if result bundle not nil before dereferencing

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -321,6 +321,12 @@ func (p *Provider) GetKeyVaultObjectContent(ctx context.Context, kvObject KeyVau
 		if err != nil {
 			return "", "", wrapObjectTypeError(err, kvObject.ObjectType, kvObject.ObjectName, kvObject.ObjectVersion)
 		}
+		if secret.Value == nil {
+			return "", "", errors.Errorf("secret value is nil")
+		}
+		if secret.ID == nil {
+			return "", "", errors.Errorf("secret id is nil")
+		}
 		content := *secret.Value
 		version := getObjectVersion(*secret.ID)
 		// if the secret is part of a certificate, then we need to convert the certificate and key to PEM format
@@ -349,6 +355,12 @@ func (p *Provider) GetKeyVaultObjectContent(ctx context.Context, kvObject KeyVau
 		keybundle, err := kvClient.GetKey(ctx, *vaultURL, kvObject.ObjectName, kvObject.ObjectVersion)
 		if err != nil {
 			return "", "", wrapObjectTypeError(err, kvObject.ObjectType, kvObject.ObjectName, kvObject.ObjectVersion)
+		}
+		if keybundle.Key == nil {
+			return "", "", errors.Errorf("key value is nil")
+		}
+		if keybundle.Key.Kid == nil {
+			return "", "", errors.Errorf("key id is nil")
 		}
 		version := getObjectVersion(*keybundle.Key.Kid)
 		// for object type "key" the public key is written to the file in PEM format
@@ -420,6 +432,12 @@ func (p *Provider) GetKeyVaultObjectContent(ctx context.Context, kvObject KeyVau
 		certbundle, err := kvClient.GetCertificate(ctx, *vaultURL, kvObject.ObjectName, kvObject.ObjectVersion)
 		if err != nil {
 			return "", "", wrapObjectTypeError(err, kvObject.ObjectType, kvObject.ObjectName, kvObject.ObjectVersion)
+		}
+		if certbundle.Cer == nil {
+			return "", "", errors.Errorf("certificate value is nil")
+		}
+		if certbundle.ID == nil {
+			return "", "", errors.Errorf("certificate id is nil")
 		}
 		version := getObjectVersion(*certbundle.ID)
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Checks if secret/key/cert is not nil before dereferencing to get value and ID.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/532

**Does this change contain code from or inspired by another project?**

- [x] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
