### PR TITLE
Add clarity about Service Principal being the only Identity Access Mode allowed for non Azure environments

### DIFF
--- a/website/content/en/configurations/identity-access-modes/service-principal-mode.md
+++ b/website/content/en/configurations/identity-access-modes/service-principal-mode.md
@@ -8,7 +8,8 @@ description: >
 ---
 
 > Supported with Linux and Windows
-> Currently this is the only way to connect to Azure Key Vault from a non Azure environment.
+
+> The only supported way to connect to Azure Key Vault from a non Azure environment.
 
 <details>
 <summary>Examples</summary>
@@ -71,7 +72,7 @@ spec:
 
 ## Configure Service Principal to access Keyvault
 
-1. Add your service principal credentials as a Kubernetes secrets accessible by the Secrets Store CSI driver. If using AKS you can learn about [service principals in AKS here.](https://docs.microsoft.com/azure/aks/kubernetes-service-principal) Service Principal is currently the only way to connect to Azure Key Vault from a non Azure environment.
+1. Add your service principal credentials as a Kubernetes secrets accessible by the Secrets Store CSI driver. If using AKS you can learn about [service principals in AKS here.](https://docs.microsoft.com/azure/aks/kubernetes-service-principal) 
 
     A properly configured service principal will need to be passed in with the Service Principal's `appId` and `password`. Ensure this service principal has all the required permissions to access content in your Azure Key Vault instance.
 

--- a/website/content/en/configurations/identity-access-modes/service-principal-mode.md
+++ b/website/content/en/configurations/identity-access-modes/service-principal-mode.md
@@ -4,7 +4,7 @@ title: "Service Principal"
 linkTitle: "Service Principal"
 weight: 1
 description: >
-  Use a Service Principal to access Keyvault.
+  Use a Service Principal to access Keyvault. ** This is currently the only way to connect to Azure Key Vault from a non Azure environment.
 ---
 
 > Supported with Linux and Windows
@@ -70,7 +70,7 @@ spec:
 
 ## Configure Service Principal to access Keyvault
 
-1. Add your service principal credentials as a Kubernetes secrets accessible by the Secrets Store CSI driver. If using AKS you can learn about [service principals in AKS here.](https://docs.microsoft.com/azure/aks/kubernetes-service-principal)
+1. Add your service principal credentials as a Kubernetes secrets accessible by the Secrets Store CSI driver. If using AKS you can learn about [service principals in AKS here.](https://docs.microsoft.com/azure/aks/kubernetes-service-principal) Service Principal is currently the only way to connect to Azure Key Vault from a non Azure environment.
 
     A properly configured service principal will need to be passed in with the Service Principal's `appId` and `password`. Ensure this service principal has all the required permissions to access content in your Azure Key Vault instance.
 

--- a/website/content/en/configurations/identity-access-modes/service-principal-mode.md
+++ b/website/content/en/configurations/identity-access-modes/service-principal-mode.md
@@ -4,10 +4,11 @@ title: "Service Principal"
 linkTitle: "Service Principal"
 weight: 1
 description: >
-  Use a Service Principal to access Keyvault. ** This is currently the only way to connect to Azure Key Vault from a non Azure environment.
+  Use a Service Principal to access Keyvault. 
 ---
 
 > Supported with Linux and Windows
+> Currently this is the only way to connect to Azure Key Vault from a non Azure environment.
 
 <details>
 <summary>Examples</summary>

--- a/website/content/en/getting-started/usage/_index.md
+++ b/website/content/en/getting-started/usage/_index.md
@@ -82,7 +82,7 @@ To provide identity to access key vault, refer to the following [section](#provi
 
 The Azure Key Vault Provider offers four modes for accessing a Key Vault instance:
 
-1. [Service Principal](../../configurations/identity-access-modes/service-principal-mode)
+1. [Service Principal](../../configurations/identity-access-modes/service-principal-mode) ** This is currently the only way to connect to Azure Key Vault from a non Azure environment.
 2. [Pod Identity](../../configurations/identity-access-modes/pod-identity-mode)
 3. [User-assigned Managed Identity](../../configurations/identity-access-modes/user-assigned-msi-mode)
 4. [System-assigned Managed Identity](../../configurations/identity-access-modes/system-assigned-msi-mode)


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
My team just wasted a week fighting to get User-assigned Managed Identity to work for on-premises kubernetes cluster, including open a support ticket with Azure, which bounced from the Azure Key Vault team to the Identity and Access Management team.  After seeing @nilekhc's comment in issue #514, we discovered that Service Principal is the only option for us.  We could have saved a lot of time if the documentation we were following made it clear that for non Azure environments such as ours, Service Principal was our only option.

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**Special Notes for Reviewers**:
none