### PR TITLE
fix: add syncSecret.enabled=true in helm install for load test

### DIFF
--- a/.pipelines/templates/load-test.yaml
+++ b/.pipelines/templates/load-test.yaml
@@ -54,6 +54,7 @@ jobs:
             --set image.repository=${REGISTRY}/provider-azure \
             --set image.tag=${IMAGE_VERSION} \
             --set secrets-store-csi-driver.enableSecretRotation=true \
+            --set secrets-store-csi-driver.syncSecret.enabled=true \
             --dependency-update
 
           envsubst < test/load/config-deployment-template.yaml > test/load/config.yaml


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds `secrets-store-csi-driver.syncSecret.enabled=true` for helm install in load test pipeline.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
