### PR TITLE
docs: add note for `syncSecret.enabled=true`

### DIFF
--- a/website/content/en/configurations/set-env-var.md
+++ b/website/content/en/configurations/set-env-var.md
@@ -11,6 +11,7 @@ description: >
 <summary>Examples</summary>
 
 - `SecretProviderClass`
+
 ```yaml
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
@@ -41,9 +42,10 @@ spec:
           objectType: key
           objectVersion: $KEY_VERSION
     tenantId: "tid"                             # the tenant ID of the KeyVault
-``` 
+```
 
 - `Pod` yaml
+
 ```yaml
 kind: Pod
 apiVersion: v1
@@ -74,6 +76,7 @@ spec:
         volumeAttributes:
           secretProviderClass: "azure-sync"
 ```
+
 </details>
 
 ### Configure your environment variable to reference a Kubernetes Secret
@@ -95,4 +98,5 @@ spec:
           name: foosecret
           key: username
 ```
+
 Here is a sample [deployment yaml](https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/examples/sync-as-kubernetes-secret/deployment-synck8s.yaml) that creates an ENV VAR from the synced Kubernetes secret.

--- a/website/content/en/configurations/sync-with-k8s-secrets.md
+++ b/website/content/en/configurations/sync-with-k8s-secrets.md
@@ -11,6 +11,7 @@ description: >
 <summary>Examples</summary>
 
 - `SecretProviderClass`
+
 ```yaml
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
@@ -41,9 +42,10 @@ spec:
           objectType: key
           objectVersion: $KEY_VERSION
     tenantId: "tid"                             # the tenant ID of the KeyVault
-``` 
+```
 
 - `Pod` yaml
+
 ```yaml
 kind: Pod
 apiVersion: v1
@@ -68,6 +70,7 @@ spec:
         volumeAttributes:
           secretProviderClass: "azure-sync"
 ```
+
 </details>
 
 ### How to sync mounted content with Kubernetes secret
@@ -75,6 +78,8 @@ spec:
 In some cases, you may want to create a Kubernetes Secret to mirror the mounted content. Use the optional `secretObjects` field to define the desired state of the synced Kubernetes secret objects.
 
 > NOTE: Make sure the `objectName` in `secretObjects` matches the file name of the mounted content. If object alias used, then it should be the object alias else this would be the object name.
+
+> If the driver and provider have been installed using helm, ensure the `syncSecret.enabled=true` helm value is set as part of install/upgrade. This is required to install the RBAC clusterrole and clusterrolebinding required by the CSI driver to sync mounted content as Kubernetes secret. For a list of customizable values that can be injected when invoking helm install, please see the [Helm chart configurations](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/charts/csi-secrets-store-provider-azure/README.md#configuration).
 
 {{% alert title="NOTE" color="warning" %}}
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds a note about setting `syncSecret.enabled=true` for using sync secret feature.
- Adds to troubleshooting guide.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
