### PR TITLE
chore: set allowPrivilegeEscalation to false

### DIFF
--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
@@ -68,6 +68,7 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             runAsUser: 0
             capabilities:
               drop:

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer.yaml
@@ -67,6 +67,7 @@ spec:
             privileged: true
           {{- end }}
           securityContext:
+            allowPrivilegeEscalation: false
             runAsUser: 0
             capabilities:
               drop:

--- a/manifest_staging/deployment/provider-azure-installer.yaml
+++ b/manifest_staging/deployment/provider-azure-installer.yaml
@@ -49,6 +49,7 @@ spec:
               cpu: 50m
               memory: 100Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsUser: 0
             capabilities:
               drop:

--- a/manifest_staging/deployment/provider-azure-installer.yaml
+++ b/manifest_staging/deployment/provider-azure-installer.yaml
@@ -50,6 +50,7 @@ spec:
               memory: 100Mi
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             runAsUser: 0
             capabilities:
               drop:


### PR DESCRIPTION
Signed-off-by: Nilekh Chaudhari <1626598+nilekhc@users.noreply.github.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
This PR adds following additional security context.
1. `allowPrivilegeEscalation: false`
2. `readOnlyRootFilesystem: true`

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #537 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
