### PR TITLE
chore: log pod identity response for error

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -94,15 +94,15 @@ func (c Config) GetServicePrincipalToken(podName, podNamespace, resource, aadEnd
 			return nil, err
 		}
 		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("nmi response failed with status code: %d, err: %+v", resp.StatusCode, err)
-		}
-
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("nmi response failed with status code: %d, response body: %+v", resp.StatusCode, string(bodyBytes))
+		}
+
 		var nmiResp = new(NMIResponse)
 		err = json.Unmarshal(bodyBytes, &nmiResp)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
Logs the response which contains error with pod identity.

Example:
```bash
E0623 17:59:23.823541       1 server.go:55] "failed to process mount request" err="failed to get keyvault client: failed to get key vault token: nmi response failed with status code: 404, err: getting assigned identities for pod default/nginx-b64f4d687-jnppl in CREATED state failed after 1 attempts, retry duration [2]s, error: <nil>. Check MIC pod logs for identity assignment errors\n"
```

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
