### PR TITLE
docs: set secrets-store-csi-driver.syncSecret.enabled for sync secret

### DIFF
--- a/website/content/en/configurations/sync-with-k8s-secrets.md
+++ b/website/content/en/configurations/sync-with-k8s-secrets.md
@@ -79,7 +79,7 @@ In some cases, you may want to create a Kubernetes Secret to mirror the mounted 
 
 > NOTE: Make sure the `objectName` in `secretObjects` matches the file name of the mounted content. If object alias used, then it should be the object alias else this would be the object name.
 
-> If the driver and provider have been installed using helm, ensure the `syncSecret.enabled=true` helm value is set as part of install/upgrade. This is required to install the RBAC clusterrole and clusterrolebinding required by the CSI driver to sync mounted content as Kubernetes secret. For a list of customizable values that can be injected when invoking helm install, please see the [Helm chart configurations](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/charts/csi-secrets-store-provider-azure/README.md#configuration).
+> If the driver and provider have been installed using helm, ensure the `secrets-store-csi-driver.syncSecret.enabled=true` helm value is set as part of install/upgrade. This is required to install the RBAC clusterrole and clusterrolebinding required by the CSI driver to sync mounted content as Kubernetes secret. For a list of customizable values that can be injected when invoking helm install, please see the [Helm chart configurations](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/charts/csi-secrets-store-provider-azure/README.md#configuration).
 
 {{% alert title="NOTE" color="warning" %}}
 

--- a/website/content/en/troubleshooting/_index.md
+++ b/website/content/en/troubleshooting/_index.md
@@ -144,7 +144,7 @@ If you received the following error message in the `secret-store` container in d
 E0610 22:27:02.283100       1 secretproviderclasspodstatus_controller.go:325] "failed to create Kubernetes secret" err="secrets is forbidden: User \"system:serviceaccount:default:secrets-store-csi-driver\" cannot create resource \"secrets\" in API group \"\" in the namespace \"default\"" spc="default/azure-linux" pod="default/busybox-linux-5f479855f7-jvfw4" secret="default/dockerconfig" spcps="default/busybox-linux-5f479855f7-jvfw4-default-azure-linux"
 ```
 
-It means the RBAC clusterrole and clusterrolebinding required for the CSI driver required to sync the mounted content as Kubernetes secret is not installed. When installing/upgrading the driver and provider using helm charts from this [repo](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/charts/csi-secrets-store-provider-azure), set `--secrets-store-csi-driver.syncSecret.enabled=true`. This will install the required clusterrole and clusterrolebinding.
+It means the RBAC clusterrole and clusterrolebinding required for the CSI driver required to sync the mounted content as Kubernetes secret is not installed. When installing/upgrading the driver and provider using helm charts from this [repo](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/charts/csi-secrets-store-provider-azure), set `secrets-store-csi-driver.syncSecret.enabled=true`. This will install the required clusterrole and clusterrolebinding.
 
 Run the following commands to verify:
 

--- a/website/content/en/upgrading/_index.md
+++ b/website/content/en/upgrading/_index.md
@@ -15,7 +15,7 @@ description: >
 
 - `syncSecret.enabled` has been set to false by default. This means the RBAC clusterrole and clusterrolebinding required for [sync mounted content as Kubernetes secret](../configurations/sync-with-k8s-secrets) will no longer be created by default as part of `helm install/upgrade`. If you're using the driver to sync mounted content as Kubernetes secret, you'll need to set `secrets-store-csi-driver.syncSecret.enabled=true` as part of `helm install/upgrade`.
 
-If the `syncSecret.enabled=true` isn't explicitly set in `helm install/upgrade` command, it'll result in failure to create Kubernetes secret and the error would be similar to:
+If the `secrets-store-csi-driver.syncSecret.enabled=true` isn't explicitly set in `helm install/upgrade` command, it'll result in failure to create Kubernetes secret and the error would be similar to:
 
 ```bash
 E0610 22:27:02.283100       1 secretproviderclasspodstatus_controller.go:325] "failed to create Kubernetes secret" err="secrets is forbidden: User \"system:serviceaccount:default:secrets-store-csi-driver\" cannot create resource \"secrets\" in API group \"\" in the namespace \"default\"" spc="default/azure-linux" pod="default/busybox-linux-5f479855f7-jvfw4" secret="default/dockerconfig" spcps="default/busybox-linux-5f479855f7-jvfw4-default-azure-linux"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Explicitly set `secrets-store-csi-driver.syncSecret.enabled=true` in the docs.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #553 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
