### PR TITLE
docs: adds release management doc

### DIFF
--- a/docs/Release_Management.md
+++ b/docs/Release_Management.md
@@ -14,7 +14,7 @@ This document describes **Azure Key Vault Provider for Secrets Store CSI Driver*
 
 
 ## Versioning
-This project strictly follows [semantic versioning](https://semver.org/spec/v2.0.0.html). All releases will be of the form _vX.Y.Z_ where X is the major version, Y is the minor version and Z is the patch version. Current releases do not have version prefix *_`v`_*. Starting 0.1.0 we will start adding version prefix, viz., _`v0.1.0`_
+This project strictly follows [semantic versioning](https://semver.org/spec/v2.0.0.html). All releases will be of the form _vX.Y.Z_ where X is the major version, Y is the minor version and Z is the patch version. Current releases do not have version prefix *_`v`_*. Starting 0.1.0 we will add the version prefix, viz., _`v0.1.0`_
 
 ### Patch releases
 - Patch releases provide users with bug fixes and security fixes. They do not contain new features.

--- a/docs/Release_Management.md
+++ b/docs/Release_Management.md
@@ -1,0 +1,49 @@
+# Release Management
+
+## Overview
+This document describes **Azure Key Vault Provider for Secrets Store CSI Driver** project release management, which talks about versioning, branching and cadence.
+
+## Legend
+
+- **X.Y.Z** refers to the version (git tag) of AKV provider for Secrets Store CSI Driver that is released. This is the version of the AKV provider for Secrets Store CSI Driver image.
+ 
+- **Milestone** should be designed to include feature sets to accommodate monthly release cycles including test gates. GitHub milestones are used by maintainers to manage each release. PRs and Issues for each release should be created as part of a corresponding milestone.
+
+- **Test gates** should include soak tests and upgrade tests from the last minor version.
+
+
+## Versioning
+This project strictly follows [semantic versioning](https://semver.org/spec/v2.0.0.html). All releases will be of the form _vX.Y.Z_ where X is the major version, Y is the minor version and Z is the patch version.
+
+### Patch releases
+- Patch releases provide users with bug fixes and security fixes. They do not contain new features.
+
+### Minor releases
+- Minor releases contain security and bug fixes as well as _**new features**_.
+
+- They are backwards compatible.
+
+### Major releases
+- Major releases contain breaking changes. Breaking changes refer to schema changes and behavior changes of Secrets Store CSI Driver that may require a clean install during upgrade and it may introduce changes that could break backward compatibility.
+
+- Ideally we will avoid making multiple major releases to be always backward compatible, unless project evolves in important new directions and such release is necessary.
+
+- AKV provider for Secrets Store CSI Driver is currently tracking towards first stable release(v1.0.0) with [this](https://github.com/Azure/secrets-store-csi-driver-provider-azure/milestone/5) milestone.
+
+
+
+## Release Cadence and Branching
+- AKV provider for Secrets Store CSI Driver follows `monthly` release schedule.
+
+- A new release should be created in _`second week`_ of each month. This schedule not only allows us to do bug fixes, but also provides an opportunity to address underline image vulnerabilities etc. if any.
+
+- The release candidate (RC) images will be published from the master branch with tags. Once we validate RC image, we'll cut a release branch.
+
+- The new version is decided as per above guideline and release branch should be created from `master` with name `release-<version>`. For eg. `release-v0.1.0`. Then build the image from release branch.
+
+- Any `fixes` or `patches` should be merged to master and then `cherry pick` to the release branch.
+
+
+## Acknowledgement
+
+This document builds on the ideas and implementations of release processes from projects like [Gatekeeper](https://github.com/open-policy-agent/gatekeeper/blob/master/docs/Release_Management.md), [Helm](https://helm.sh/docs/topics/release_policy/#helm) and Kubernetes. 

--- a/docs/Release_Management.md
+++ b/docs/Release_Management.md
@@ -1,4 +1,5 @@
 # Release Management
+> Note: This document is work in progress.
 
 ## Overview
 This document describes **Azure Key Vault Provider for Secrets Store CSI Driver** project release management, which talks about versioning, branching and cadence.
@@ -13,7 +14,7 @@ This document describes **Azure Key Vault Provider for Secrets Store CSI Driver*
 
 
 ## Versioning
-This project strictly follows [semantic versioning](https://semver.org/spec/v2.0.0.html). All releases will be of the form _vX.Y.Z_ where X is the major version, Y is the minor version and Z is the patch version.
+This project strictly follows [semantic versioning](https://semver.org/spec/v2.0.0.html). All releases will be of the form _vX.Y.Z_ where X is the major version, Y is the minor version and Z is the patch version. Current releases do not have version prefix *_`v`_*. Starting 0.1.0 we will start adding version prefix, viz., _`v0.1.0`_
 
 ### Patch releases
 - Patch releases provide users with bug fixes and security fixes. They do not contain new features.
@@ -35,7 +36,7 @@ This project strictly follows [semantic versioning](https://semver.org/spec/v2.0
 ## Release Cadence and Branching
 - AKV provider for Secrets Store CSI Driver follows `monthly` release schedule.
 
-- A new release should be created in _`second week`_ of each month. This schedule not only allows us to do bug fixes, but also provides an opportunity to address underline image vulnerabilities etc. if any.
+- A new release would be created in _`second week`_ of each month. This schedule not only allows us to do bug fixes, but also provides an opportunity to address underlying image vulnerabilities if any.
 
 - The release candidate (RC) images will be published from the master branch with tags. Once we validate RC image, we'll cut a release branch.
 


### PR DESCRIPTION
Signed-off-by: Nilekh Chaudhari <1626598+nilekhc@users.noreply.github.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
This PR adds release management process doc.
<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes: #507 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
