### PR TITLE
docs: add nodepublishsecretref namespace limitation

### DIFF
--- a/website/content/en/configurations/identity-access-modes/service-principal-mode.md
+++ b/website/content/en/configurations/identity-access-modes/service-principal-mode.md
@@ -91,6 +91,8 @@ spec:
     The Kubernetes Secret containing the credentials need to be created in the same namespace as the application pod. If pods in multiple namespaces need to use the same SP to access Keyvault, this Kubernetes Secret needs to be created in each namespace.
     {{% /alert %}}
 
+    The requirement for `nodePublishSecretRef` to be in the same namespace as the pod referencing it in volume is imposed by the Kubernetes core object type. In case of CSI Volumes, the `nodePublishSecretRef` is a [LocalObjectReference](https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#LocalObjectReference) which only accepts the name of the secret. The namespace is always [defaulted to the pod namespace for the secret](https://github.com/kubernetes/kubernetes/blob/release-1.18/pkg/volume/csi/csi_mounter.go#L169-L171). In case of `PersistentVolume` the `nodePublishSecretRef` is a [secretRef](https://pkg.go.dev/k8s.io/api/core/v1?tab=doc#SecretReference) which accepts both name and namespace.
+
     **If you do not have a service principal**, run the following Azure CLI command to create a new service principal.
 
     ```bash


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
Adds explanation for the `nodePublishSecretRef` namespace limitation.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #531 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
