### PR TITLE
docs: adds sample cmds to test AKV connectivity

### DIFF
--- a/website/content/en/troubleshooting/_index.md
+++ b/website/content/en/troubleshooting/_index.md
@@ -136,6 +136,40 @@ Past issues:
 - https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/292
 - https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/471
 
+You can test Azure Key Vault connectivity from pod running on host network as follows:
+- Create Pod
+```yaml
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: curl
+spec:
+  hostNetwork: true
+  containers:
+  - args:
+    - tail
+    - -f
+    - /dev/null
+    image: curlimages/curl:7.75.0
+    name: curl
+  dnsPolicy: ClusterFirst
+  restartPolicy: Always
+EOF
+```
+- Exec into the Pod created above
+```
+kubectl exec -it curl -- sh
+```
+- Authenticate with AKV
+```
+curl -X POST 'https://login.microsoftonline.com/<AAD_TENANT_ID>/oauth2/v2.0/token' -d 'grant_type=client_credentials&client_id=<AZURE_CLIENT_ID>&client_secret=<AZURE_CLIENT_SECRET>&scope=https://vault.azure.net/.default'
+```
+- Try getting secret which is already created in AKV
+```
+curl -X GET 'https://<KEY_VAULT_NAME>.vault.azure.net/secrets/<SECRET_NAME>?api-version=7.2' -H "Authorization: Bearer <ACCESS_TOKEN_ACQUIRED_ABOVE>"
+```
+
 ### "failed to create Kubernetes secret" err="secrets is forbidden: User \"system:serviceaccount:default:secrets-store-csi-driver\" cannot create resource \"secrets\" in API group \"\" in the namespace \"default\""
 
 If you received the following error message in the `secret-store` container in driver:

--- a/website/content/en/troubleshooting/_index.md
+++ b/website/content/en/troubleshooting/_index.md
@@ -168,7 +168,7 @@ curl -X POST 'https://login.microsoftonline.com/<AAD_TENANT_ID>/oauth2/v2.0/toke
 - Try getting secret which is already created in AKV
 ```
 curl -X GET 'https://<KEY_VAULT_NAME>.vault.azure.net/secrets/<SECRET_NAME>?api-version=7.2' -H "Authorization: Bearer <ACCESS_TOKEN_ACQUIRED_ABOVE>"
-```
+``` 
 
 ### "failed to create Kubernetes secret" err="secrets is forbidden: User \"system:serviceaccount:default:secrets-store-csi-driver\" cannot create resource \"secrets\" in API group \"\" in the namespace \"default\""
 


### PR DESCRIPTION
Signed-off-by: Nilekh Chaudhari <1626598+nilekhc@users.noreply.github.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
This PR adds sample commands to test AKV connectivity from pod running on host network.
<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes: #552 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
