### PR TITLE
docs: add note about the lifetime of synced k8s secrets

### DIFF
--- a/website/content/en/configurations/sync-with-k8s-secrets.md
+++ b/website/content/en/configurations/sync-with-k8s-secrets.md
@@ -85,6 +85,7 @@ In some cases, you may want to create a Kubernetes Secret to mirror the mounted 
 
 - The secrets will only sync once you *start a pod mounting the secrets*. Solely relying on the syncing with Kubernetes secrets feature thus does not work.
 - The Kubernetes secrets will be synced to the same namespace as the application pod and `SecretProviderClass`.
+- When all the pods consuming the secret are deleted, the Kubernetes secret is also deleted. This is done by adding the pods as owners to the created Kubernetes secret. When all the application pods consuming the Kubernetes secret are deleted, the Kubernetes secret will be garbage collected.
 {{% /alert %}}
 
 A `SecretProviderClass` custom resource should have the following components:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
Adds note about the lifetime of the synced Kubernetes secret tied to the pods consuming it.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #321 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
