### PR TITLE
helm: move helm dependencies to Chart.yaml

### DIFF
--- a/manifest_staging/charts/csi-secrets-store-provider-azure/Chart.lock
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/Chart.lock
@@ -2,4 +2,5 @@ dependencies:
 - name: secrets-store-csi-driver
   repository: https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
   version: 0.1.0
-  condition: secrets-store-csi-driver.install
+digest: sha256:eaadf56a2f3fbb979352636c5088c8ee167e34ab0e76cef582dd8f31a4837f41
+generated: "2021-07-29T11:13:19.767734-07:00"

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/Chart.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/Chart.yaml
@@ -10,3 +10,8 @@ home: https://github.com/Azure/secrets-store-csi-driver-provider-azure
 maintainers:
   - name: Anish Ramasekar
     email: anish.ramasekar@gmail.com
+dependencies:
+- name: secrets-store-csi-driver
+  repository: https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
+  version: 0.1.0
+  condition: secrets-store-csi-driver.install

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/requirements.lock
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: secrets-store-csi-driver
-  repository: https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
-  version: 0.1.0
-digest: sha256:eaadf56a2f3fbb979352636c5088c8ee167e34ab0e76cef582dd8f31a4837f41
-generated: "2021-07-26T14:17:34.637877-07:00"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
In helm3 the `requirements.yaml` has been consolidated into `Chart.yaml`: https://helm.sh/docs/faq/changes_since_helm2/#consolidation-of-requirementsyaml-into-chartyaml

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
