### PR TITLE
chore: make `--driver-write-secrets` flag no-op

### DIFF
--- a/.pipelines/templates/e2e-test-kind.yaml
+++ b/.pipelines/templates/e2e-test-kind.yaml
@@ -1,51 +1,45 @@
-parameters:
-  - name: driverWriteSecrets
-    type: object
-
 jobs:
-  - ${{ each driverWriteSecret in parameters.driverWriteSecrets }}:
-    - job:
-      displayName: ${{ format('e2e_test_kind/driver-write-secrets={0}', driverWriteSecret) }}
-      timeoutInMinutes: 10
-      cancelTimeoutInMinutes: 5
-      workspace:
-        clean: all
-      variables:
-      - group: csi-secrets-store-e2e-kind
-      steps:
-        - task: GoTool@0
-          inputs:
-            version: 1.16
-        - script: |
-            export REGISTRY="e2e"
-            export IMAGE_VERSION=e2e-$(git rev-parse --short HEAD)
-            echo "Image version: ${IMAGE_VERSION}"
-            echo "##vso[task.setvariable variable=IMAGE_VERSION]${IMAGE_VERSION}"
-            echo "##vso[task.setvariable variable=REGISTRY]${REGISTRY}"
-            make e2e-bootstrap
-          displayName: "Build image"
-          env:
-            CI_KIND_CLUSTER: true
-        - script: |
-            make e2e-test
-          displayName: "Run e2e tests on kind cluster"
-          env:
-            AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-            AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
-            KEY_NAME: $(KEY_NAME)
-            KEY_VERSION: $(KEY_VERSION)
-            KEYVAULT_NAME: $(KEYVAULT_NAME)
-            SECRET_NAME: $(SECRET_NAME)
-            TENANT_ID: $(TENANT_ID)
-            CI_KIND_CLUSTER: true
-            AZURE_ENVIRONMENT_FILEPATH: "/etc/kubernetes/custom_environment.json"
-            ${{ if eq(driverWriteSecret, 'false') }}:
-              DRIVER_WRITE_SECRETS: false
+  - job:
+    displayName: e2e_test_kind/helm
+    timeoutInMinutes: 10
+    cancelTimeoutInMinutes: 5
+    workspace:
+      clean: all
+    variables:
+    - group: csi-secrets-store-e2e-kind
+    steps:
+      - task: GoTool@0
+        inputs:
+          version: 1.16
+      - script: |
+          export REGISTRY="e2e"
+          export IMAGE_VERSION=e2e-$(git rev-parse --short HEAD)
+          echo "Image version: ${IMAGE_VERSION}"
+          echo "##vso[task.setvariable variable=IMAGE_VERSION]${IMAGE_VERSION}"
+          echo "##vso[task.setvariable variable=REGISTRY]${REGISTRY}"
+          make e2e-bootstrap
+        displayName: "Build image"
+        env:
+          CI_KIND_CLUSTER: true
+      - script: |
+          make e2e-test
+        displayName: "Run e2e tests on kind cluster"
+        env:
+          AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
+          AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+          KEY_NAME: $(KEY_NAME)
+          KEY_VERSION: $(KEY_VERSION)
+          KEYVAULT_NAME: $(KEYVAULT_NAME)
+          SECRET_NAME: $(SECRET_NAME)
+          TENANT_ID: $(TENANT_ID)
+          CI_KIND_CLUSTER: true
+          AZURE_ENVIRONMENT_FILEPATH: "/etc/kubernetes/custom_environment.json"
+
+      - script: |
+          make e2e-kind-cleanup
+        displayName: 'Delete kind cluster'
+        condition: always()
   
-        - script: |
-            make e2e-kind-cleanup
-          displayName: 'Delete kind cluster'
-          condition: always()
   - job:
     displayName: e2e_test_kind/deployment_manifest
     timeoutInMinutes: 10

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,3 @@ pool:
 jobs:
   - template: .pipelines/templates/unit-test.yaml
   - template: .pipelines/templates/e2e-test-kind.yaml
-    parameters:
-      driverWriteSecrets:
-      - "true"
-      - "false"

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -33,8 +33,7 @@ import (
 )
 
 var (
-	ConstructPEMChain  = flag.Bool("construct-pem-chain", true, "explicitly reconstruct the pem chain in the order: SERVER, INTERMEDIATE, ROOT")
-	DriverWriteSecrets = flag.Bool("driver-write-secrets", true, "Return secrets in gRPC response to the driver (supported in driver v0.0.21+) instead of writing to filesystem")
+	ConstructPEMChain = flag.Bool("construct-pem-chain", true, "explicitly reconstruct the pem chain in the order: SERVER, INTERMEDIATE, ROOT")
 )
 
 // Type of Azure Key Vault objects
@@ -289,18 +288,10 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 		if err != nil {
 			return nil, nil, err
 		}
-		// if the feature to return secrets to CSI driver isn't enabled, the provider will continue to write
-		// the contents to the filesystem.
-		if !*DriverWriteSecrets {
-			if err := os.WriteFile(filepath.Join(targetPath, fileName), objectContent, permission); err != nil {
-				return nil, nil, errors.Wrapf(err, "failed to write file %s at %s", fileName, targetPath)
-			}
-			klog.InfoS("successfully wrote file", "file", fileName, "pod", klog.ObjectRef{Namespace: p.PodNamespace, Name: p.PodName})
-		} else {
-			// these files will be returned to the CSI driver as part of gRPC response
-			files[fileName] = objectContent
-			klog.InfoS("added file to the gRPC response", "file", fileName, "pod", klog.ObjectRef{Namespace: p.PodNamespace, Name: p.PodName})
-		}
+
+		// these files will be returned to the CSI driver as part of gRPC response
+		files[fileName] = objectContent
+		klog.InfoS("added file to the gRPC response", "file", fileName, "pod", klog.ObjectRef{Namespace: p.PodNamespace, Name: p.PodName})
 	}
 
 	return files, objectVersionMap, nil

--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -30,7 +30,6 @@ type Config struct {
 	HelmChartDir                      string `envconfig:"HELM_CHART_DIR" default:"manifest_staging/charts/csi-secrets-store-provider-azure"`
 	IsClusterUpgraded                 bool   `envconfig:"IS_CLUSTER_UPGRADED"`
 	IsBackwardCompatibilityTest       bool   `envconfig:"IS_BACKWARD_COMPATIBILITY_TEST"`
-	DriverWriteSecrets                bool   `envconfig:"DRIVER_WRITE_SECRETS" default:"true"`
 	AzureEnvironmentFilePath          string `envconfig:"AZURE_ENVIRONMENT_FILEPATH"`
 }
 
@@ -57,7 +56,6 @@ func (c *Config) DeepCopy() *Config {
 	copy.HelmChartDir = c.HelmChartDir
 	copy.IsClusterUpgraded = c.IsClusterUpgraded
 	copy.IsBackwardCompatibilityTest = c.IsBackwardCompatibilityTest
-	copy.DriverWriteSecrets = c.DriverWriteSecrets
 	copy.AzureEnvironmentFilePath = c.AzureEnvironmentFilePath
 	copy.IsHelmTest = c.IsHelmTest
 

--- a/test/e2e/framework/helm/helm.go
+++ b/test/e2e/framework/helm/helm.go
@@ -160,13 +160,9 @@ func generateValueArgs(config *framework.Config) []string {
 		fmt.Sprintf("--set=windows.image.repository=%s/%s", config.Registry, config.ImageName),
 	}
 
-	//Set image.tag only if there is an image version provided. Else rely on default values.
+	// Set image.tag only if there is an image version provided. Else rely on default values.
 	if config.ImageVersion != "" {
 		args = append(args, fmt.Sprintf("--set=linux.image.tag=%s", config.ImageVersion), fmt.Sprintf("--set=windows.image.tag=%s", config.ImageVersion))
-	}
-
-	if config.DriverWriteSecrets {
-		args = append(args, fmt.Sprintf("--set=driverWriteSecrets=true"))
 	}
 
 	// add the custom env file volume and mount if exists


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
Driver write secrets feature has been enabled by default in `v0.1.0` release. This PR makes the flag configuration no-op to not allow disabling the feature. The flag will be removed altogether from code, deployment and helm charts in n+2 releases.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
