### PR TITLE
refactor: create kv client once and update to structured logging

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,10 +66,10 @@ func main() {
 		}
 		os.Exit(0)
 	}
-	klog.Infof("Starting Azure Key Vault Provider version: %s", version.BuildVersion)
+	klog.InfoS("Starting Azure Key Vault Provider", "version", version.BuildVersion)
 
 	if *enableProfile {
-		klog.Infof("Starting profiling on port %d", *profilePort)
+		klog.InfoS("Starting profiling", "port", *profilePort)
 		go func() {
 			addr := fmt.Sprintf("%s:%d", "localhost", *profilePort)
 			klog.ErrorS(http.ListenAndServe(addr, nil), "unable to start profiling server")
@@ -120,7 +120,7 @@ func main() {
 	// Register the health service.
 	grpc_health_v1.RegisterHealthServer(s, csiDriverProviderServer)
 
-	klog.Infof("Listening for connections on address: %v", listener.Addr())
+	klog.InfoS("Listening for connections", "address", listener.Addr())
 	go s.Serve(listener)
 
 	healthz := &server.HealthZ{

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -657,7 +657,7 @@ func TestInitializeKVClient(t *testing.T) {
 		azure.USGovernmentCloud,
 	}
 	for i := range testEnvs {
-		authConfig, err := auth.NewConfig(false, true, "", nil)
+		authConfig, err := auth.NewConfig(false, false, "", map[string]string{"clientid": "id", "clientsecret": "secret"})
 		assert.NoError(t, err)
 
 		mc := &mountConfig{

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ func PrintVersion() (err error) {
 // GetUserAgent returns UserAgent string to append to the agent identifier.
 func GetUserAgent() string {
 	if *customUserAgent != "" {
-		klog.V(5).Infof("Appending custom user agent: %s", *customUserAgent)
+		klog.V(5).InfoS("Appending custom user agent", "userAgent", *customUserAgent)
 		return fmt.Sprintf("csi-secrets-store/%s (%s/%s) %s/%s %s", BuildVersion, runtime.GOOS, runtime.GOARCH, Vcs, BuildDate, *customUserAgent)
 	}
 	return fmt.Sprintf("csi-secrets-store/%s (%s/%s) %s/%s", BuildVersion, runtime.GOOS, runtime.GOARCH, Vcs, BuildDate)


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
Keyvault name is per `SecretProviderClass`. So switching to just getting the vault URL and kv client once instead of recreating the client for every single object in the array.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
