### PR TITLE
chore: cleanup unit tests that have external dependency

### DIFF
--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -128,63 +128,6 @@ func TestGetServicePrincipalToken(t *testing.T) {
 	assert.Equal(t, token, spt)
 }
 
-func TestGetServicePrincipalTokenFromMSIWithUserAssignedID(t *testing.T) {
-	configs := []Config{
-		{
-			UseVMManagedIdentity:   true,
-			UserAssignedIdentityID: "UserAssignedIdentityID",
-		},
-		// uses managed identity when sp credentials are provided
-		{
-			UseVMManagedIdentity:   true,
-			UserAssignedIdentityID: "UserAssignedIdentityID",
-			AADClientID:            "AADClientID",
-			AADClientSecret:        "AADClientSecret",
-		},
-	}
-	env := &azure.PublicCloud
-
-	for _, config := range configs {
-		token, err := config.GetServicePrincipalToken("pod", "default", env.KeyVaultEndpoint, env.ActiveDirectoryEndpoint, "tenantID", "2579")
-		assert.NoError(t, err)
-
-		msiEndpoint, err := adal.GetMSIVMEndpoint()
-		assert.NoError(t, err)
-
-		spt, err := adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(msiEndpoint,
-			env.KeyVaultEndpoint, config.UserAssignedIdentityID)
-		assert.NoError(t, err)
-		assert.Equal(t, token, spt)
-	}
-}
-
-func TestGetServicePrincipalTokenFromMSI(t *testing.T) {
-	configs := []Config{
-		{
-			UseVMManagedIdentity: true,
-		},
-		// uses managed identity when sp credentials are provided
-		{
-			UseVMManagedIdentity: true,
-			AADClientID:          "AADClientID",
-			AADClientSecret:      "AADClientSecret",
-		},
-	}
-	env := &azure.PublicCloud
-
-	for _, config := range configs {
-		token, err := config.GetServicePrincipalToken("pod", "default", env.KeyVaultEndpoint, env.ActiveDirectoryEndpoint, "tenantID", "2579")
-		assert.NoError(t, err)
-
-		msiEndpoint, err := adal.GetMSIVMEndpoint()
-		assert.NoError(t, err)
-
-		spt, err := adal.NewServicePrincipalTokenFromMSI(msiEndpoint, env.KeyVaultEndpoint)
-		assert.NoError(t, err)
-		assert.Equal(t, token, spt)
-	}
-}
-
 func TestGetServicePrincipalTokenPodIdentity(t *testing.T) {
 	config := Config{
 		UsePodIdentity: true,

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -657,7 +657,7 @@ func TestInitializeKVClient(t *testing.T) {
 		azure.USGovernmentCloud,
 	}
 	for i := range testEnvs {
-		authConfig, err := auth.NewConfig(false, true, "", nil)
+		authConfig, err := auth.NewConfig(false, false, "", map[string]string{"clientid": "id", "clientsecret": "secret"})
 		assert.NoError(t, err)
 
 		mc := &mountConfig{


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
Because of changes in https://github.com/Azure/go-autorest/pull/613, the tests that depends on `adal.NewServicePrincipalTokenFromMSI` will fail as it requires the IMDS endpoints be available. There is currently no option to pass a custom msi endpoint to mimic the behavior. So this PR deletes the two test cases that depend on the function. 

The unit tests are not failing in the CI because the agents we're running the tests on are Azure VMs. So they have the IMDS endpoint.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
