### PR TITLE
chore: replace deprecated codecov uploader with GitHub action

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -1,0 +1,25 @@
+name: Codecov
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+    steps:
+      # pinning to the sha 5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f from https://github.com/actions/checkout/releases/tag/v2.3.4
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      # pinning to the sha 331ce1d993939866bb63c32c6cbbfd48fa76fc57 from https://github.com/actions/setup-go/releases/tag/v2.1.4
+      - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57
+        with:
+          go-version: "^1.17"
+      - name: Unit test
+        run: make unit-test
+      # pinning to the sha f32b3a3741e1053eb607407145bc9619351dc93b from https://github.com/codecov/codecov-action/releases/tag/v2.1.0
+      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
+        with:
+          files: ./coverage.txt

--- a/.pipelines/templates/unit-test.yaml
+++ b/.pipelines/templates/unit-test.yaml
@@ -31,5 +31,3 @@ jobs:
     steps:
       - script: make unit-test
         displayName: unit test
-      - script: bash <(curl -s https://codecov.io/bash) -C $(Build.SourceVersion)
-        displayName: Upload coverage to codecov


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/647

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
