### PR TITLE
ci: bump test timeout to 120m

### DIFF
--- a/.pipelines/templates/e2e-test-azure.yaml
+++ b/.pipelines/templates/e2e-test-azure.yaml
@@ -15,7 +15,7 @@ jobs:
     - ${{ each osType in parameters.osTypes }}:
       - job:
         displayName: ${{ format('{0}/{1}/gpu={2}', clusterType, osType, parameters.testWithGPU) }}
-        timeoutInMinutes: 90
+        timeoutInMinutes: 120
         cancelTimeoutInMinutes: 5
         workspace:
           clean: all


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
The Kubernetes cluster upgrade in nightly runs have taken a while which
causes the pipeline to timeout in 90m. Bumping it to 120m based on some
of the earlier test results to provide more time for pipeline to
complete.

Ref nightly run: https://dev.azure.com/AzureContainerUpstream/Secrets%20Store%20CSI%20Driver%20Provider%20Azure/_build/results?buildId=27623&view=results

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
