### PR TITLE
docs: add `/etc/ssl/certs` volume mount for custom cloud

### DIFF
--- a/website/content/en/configurations/custom-environments.md
+++ b/website/content/en/configurations/custom-environments.md
@@ -29,10 +29,16 @@ linux:
     - name: cloudenvfile-vol
       hostPath:
         path: "/etc/kubernetes"
+    - name: sslcerts
+      hostPath:
+        path: "/etc/ssl/certs"
   volumeMounts:
     - name: cloudenvfile-vol
       mountPath: "/cloudEnv/myCustomEnvironmentFile.json"
       subPath: "myCustomEnvironmentFile.json"
+    - name: sslcerts
+      mountPath: "/etc/ssl/certs"
+      readOnly: true
 ```
 
 ## Update Secret Provider class


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
`/etc/ssl/certs` are required in custom cloud environments to be able to communicate with the custom keyvault endpoint.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
