### PR TITLE
feat: allow empty objects array 

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -257,7 +257,7 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 	klog.InfoS("unmarshaled key vault objects", "keyVaultObjects", keyVaultObjects, "count", len(keyVaultObjects), "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
 
 	if len(keyVaultObjects) == 0 {
-		return nil, nil, fmt.Errorf("objects array is empty")
+		return make(map[string][]byte), make(map[string]string), nil
 	}
 
 	vaultURL, err := mc.getVaultURL()

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -768,7 +768,7 @@ func TestMountSecretsStoreObjectContent(t *testing.T) {
 				"objects": `
       array:`,
 			},
-			expectedErr: true,
+			expectedErr: false,
 		},
 		{
 			desc: "invalid object format",

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -35,15 +35,6 @@ func TestMount(t *testing.T) {
 			},
 			expectedErr: true,
 		},
-		{
-			desc: "failed to mount request",
-			mountRequest: &v1alpha1.MountRequest{
-				Attributes: `{"keyvaultName":"kv","tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47","objects": "array:"}`,
-				Secrets:    `{"clientid":"foo","clientsecret":"bar"}`,
-				Permission: "420",
-			},
-			expectedErr: true,
-		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
The YAML for secret provider class can be created by a template engine and all the objects listed there can depend on a template variable to be truthy. In this case, when all of them are falsy, it becomes a special case if empty objects array is not allowed. Example:

```
objects: |
  array:
{{ if condition1 }}
   - |
     objectName: "Secret1"
     objectType: secret
     objectFormat: pfx
     objectEncoding: base64
{{ end }}
{{ if condition2 }}
   - |
     objectName: "Secret2"
     objectType: secret
     objectFormat: pfx
     objectEncoding: base64
{{ end }}
```

If `condition1` and `condition2` are both falsy, the provider returns an error, but simply mounting an empty volume would be more consistent and it doesn't require special handling.

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**Special Notes for Reviewers**:
