### PR TITLE
Remove note about Kubernetes secret type constraint

### DIFF
--- a/website/content/en/configurations/sync-with-k8s-secrets.md
+++ b/website/content/en/configurations/sync-with-k8s-secrets.md
@@ -106,8 +106,6 @@ spec:
 ...
 ```
 
-> NOTE: Here is the list of supported Kubernetes Secret types: `Opaque`, `kubernetes.io/basic-auth`, `bootstrap.kubernetes.io/token`, `kubernetes.io/dockerconfigjson`, `kubernetes.io/dockercfg`, `kubernetes.io/ssh-auth`, `kubernetes.io/service-account-token`, `kubernetes.io/tls`.  
-
 - Here is a sample [`SecretProviderClass` custom resource](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/examples/sync-as-kubernetes-secret/synck8s_v1alpha1_secretproviderclass.yaml) that syncs a secret from Azure Key Vault to a Kubernetes secret.
 - To view an example of type `kubernetes.io/tls`, refer to the [example](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/examples/sync-as-kubernetes-secret/tls_synck8s_v1alpha1_secretproviderclass.yaml).
 - To view an example of type `kubernetes.io/dockerconfigjson`, refer to the [example](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/examples/sync-as-kubernetes-secret/dockerconfigjson_synck8s_v1alpha1_secretproviderclass.yaml) that syncs `dockerconfigjson` from Azure Key Vault to a Kubernetes secret.


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
Prior to [v0.3.0](https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v0.3.0) only certain secret types were considered, but this constraint was removed in v0.3.0 via PR https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/703

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
