### PR TITLE
chore: use kubernetes 1.22.2 for test and update makefile

### DIFF
--- a/.pipelines/templates/e2e-test-kind.yaml
+++ b/.pipelines/templates/e2e-test-kind.yaml
@@ -22,8 +22,8 @@ jobs:
         kind_v1_21_2_helm:
           KIND_K8S_VERSION: v1.21.2
           IS_HELM_TEST: true
-        kind_v1_22_0_helm:
-          KIND_K8S_VERSION: v1.22.0
+        kind_v1_22_2_helm:
+          KIND_K8S_VERSION: v1.22.2
           IS_HELM_TEST: true
         kind_v1_19_11_deployment_manifest:
           KIND_K8S_VERSION: v1.19.11
@@ -34,8 +34,8 @@ jobs:
         kind_v1_21_2_deployment_manifest:
           KIND_K8S_VERSION: v1.21.2
           IS_HELM_TEST: false
-        kind_v1_22_0_deployment_manifest:
-          KIND_K8S_VERSION: v1.22.0
+        kind_v1_22_2_deployment_manifest:
+          KIND_K8S_VERSION: v1.22.2
           IS_HELM_TEST: false        
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/distroless/static
-ARG ARCH
-COPY ./_output/${ARCH}/secrets-store-csi-driver-provider-azure /bin/
+ARG TARGETARCH
+COPY ./_output/${TARGETARCH}/secrets-store-csi-driver-provider-azure /bin/
 
 LABEL maintainers="aramase"
 LABEL description="Secrets Store CSI Driver Provider Azure"

--- a/windows.Dockerfile
+++ b/windows.Dockerfile
@@ -5,9 +5,9 @@ FROM mcr.microsoft.com/windows/nanoserver:${OSVERSION}
 LABEL maintainers="aramase"
 LABEL description="Secrets Store CSI Driver Provider Azure"
 
-ARG ARCH
+ARG TARGETARCH
 
-COPY ./_output/${ARCH}/secrets-store-csi-driver-provider-azure.exe /secrets-store-csi-driver-provider-azure.exe
+COPY ./_output/${TARGETARCH}/secrets-store-csi-driver-provider-azure.exe /secrets-store-csi-driver-provider-azure.exe
 COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
 USER ContainerAdministrator
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Updates default kubernetes version to `v1.22.2`
- Make docker buildx builder name customizable
- Use `TARGETARCH` instead of `ARCH` in dockerfile

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
