### PR TITLE
test: bump kubernetes version to v1.22.4 and remove v1.19

### DIFF
--- a/.pipelines/templates/e2e-test-kind.yaml
+++ b/.pipelines/templates/e2e-test-kind.yaml
@@ -13,29 +13,23 @@ jobs:
     - group: csi-secrets-store-e2e-kind
     strategy:
       matrix:
-        kind_v1_19_11_helm:
-          KIND_K8S_VERSION: v1.19.11
-          IS_HELM_TEST: true
         kind_v1_20_7_helm:
           KIND_K8S_VERSION: v1.20.7
           IS_HELM_TEST: true
         kind_v1_21_2_helm:
           KIND_K8S_VERSION: v1.21.2
           IS_HELM_TEST: true
-        kind_v1_22_2_helm:
-          KIND_K8S_VERSION: v1.22.2
+        kind_v1_22_4_helm:
+          KIND_K8S_VERSION: v1.22.4
           IS_HELM_TEST: true
-        kind_v1_19_11_deployment_manifest:
-          KIND_K8S_VERSION: v1.19.11
-          IS_HELM_TEST: false
         kind_v1_20_7_deployment_manifest:
           KIND_K8S_VERSION: v1.20.7
           IS_HELM_TEST: false
         kind_v1_21_2_deployment_manifest:
           KIND_K8S_VERSION: v1.21.2
           IS_HELM_TEST: false
-        kind_v1_22_2_deployment_manifest:
-          KIND_K8S_VERSION: v1.22.2
+        kind_v1_22_4_deployment_manifest:
+          KIND_K8S_VERSION: v1.22.4
           IS_HELM_TEST: false        
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ BUILDX_BUILDER_NAME ?= img-builder
 
 # E2E test variables
 KIND_VERSION ?= 0.11.0
-KIND_K8S_VERSION ?= v1.22.2
+KIND_K8S_VERSION ?= v1.22.4
 
 $(TOOLS_DIR)/golangci-lint: $(TOOLS_MOD_DIR)/go.mod $(TOOLS_MOD_DIR)/go.sum $(TOOLS_MOD_DIR)/tools.go
 	cd $(TOOLS_MOD_DIR) && \


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Bumps to kubernetes version `v1.22.4` for 1.22
- 1.19 is EOL, so removing 1.19 tests

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
