### PR TITLE
fix: klog verbose update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ install-helm:
 .PHONY: e2e-local-bootstrap
 e2e-local-bootstrap: build
 	kind create cluster --image kindest/node:${KIND_K8S_VERSION} --config test/kind-config.yaml
-	make image
+	$(MAKE) container-all push-manifest
 	kind load docker-image --name kind $(IMAGE_TAG)
 
 .PHONY: e2e-kind-cleanup

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -74,7 +74,7 @@ func (c Config) GetServicePrincipalToken(podName, podNamespace, resource, aadEnd
 	// The NMI server identifies the pod based on the `podns` and `podname` in the request header and then queries k8s (through MIC) for a matching azure identity.
 	// Then nmi makes an adal request to get a token for the resource in the request, returns the `token` and the `clientid` as a response to the CSI request.
 	if c.UsePodIdentity {
-		klog.InfoS("using pod identity to retrieve token", "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
+		klog.V(5).InfoS("using pod identity to retrieve token", "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
 		// pod name and namespace are required for the Key Vault provider to request a token
 		// on behalf of the application pod
 		if len(podName) == 0 || len(podNamespace) == 0 {
@@ -108,7 +108,7 @@ func (c Config) GetServicePrincipalToken(podName, podNamespace, resource, aadEnd
 		if err != nil {
 			return nil, err
 		}
-		klog.InfoS("successfully acquired access token", "accessToken", utils.RedactClientID(nmiResp.Token.AccessToken), "clientID", utils.RedactClientID(nmiResp.ClientID), "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
+		klog.V(5).InfoS("successfully acquired access token", "accessToken", utils.RedactClientID(nmiResp.Token.AccessToken), "clientID", utils.RedactClientID(nmiResp.ClientID), "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
 
 		token, clientID := nmiResp.Token, nmiResp.ClientID
 		if token.AccessToken == "" || clientID == "" {
@@ -128,14 +128,14 @@ func (c Config) GetServicePrincipalToken(podName, podNamespace, resource, aadEnd
 			return nil, errors.Wrap(err, "failed to get managed identity (MSI) endpoint")
 		}
 		if c.UserAssignedIdentityID != "" {
-			klog.InfoS("using user-assigned managed identity to retrieve access token", "clientID", utils.RedactClientID(c.UserAssignedIdentityID), "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
+			klog.V(5).InfoS("using user-assigned managed identity to retrieve access token", "clientID", utils.RedactClientID(c.UserAssignedIdentityID), "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
 			return adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(
 				msiEndpoint,
 				resource,
 				c.UserAssignedIdentityID)
 		}
 
-		klog.InfoS("using system-assigned managed identity to retrieve access token", "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
+		klog.V(5).InfoS("using system-assigned managed identity to retrieve access token", "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
 		return adal.NewServicePrincipalTokenFromMSI(
 			msiEndpoint,
 			resource)
@@ -143,7 +143,7 @@ func (c Config) GetServicePrincipalToken(podName, podNamespace, resource, aadEnd
 
 	// for Service Principal access mode, clientID + client secret are used to retrieve token for resource
 	if len(c.AADClientSecret) > 0 && len(c.AADClientID) > 0 {
-		klog.InfoS("using service principal to retrieve access token", "clientID", utils.RedactClientID(c.AADClientID), "secret", utils.RedactClientID(c.AADClientSecret), "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
+		klog.V(5).InfoS("using service principal to retrieve access token", "clientID", utils.RedactClientID(c.AADClientID), "secret", utils.RedactClientID(c.AADClientSecret), "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
 		return adal.NewServicePrincipalToken(
 			*oauthConfig,
 			c.AADClientID,

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -254,7 +254,7 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 		keyVaultObjects = append(keyVaultObjects, keyVaultObject)
 	}
 
-	klog.InfoS("unmarshaled key vault objects", "keyVaultObjects", keyVaultObjects, "count", len(keyVaultObjects), "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
+	klog.V(5).InfoS("unmarshaled key vault objects", "keyVaultObjects", keyVaultObjects, "count", len(keyVaultObjects), "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
 
 	if len(keyVaultObjects) == 0 {
 		return make(map[string][]byte), make(map[string]string), nil
@@ -275,7 +275,7 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 	objectVersionMap := make(map[string]string)
 	files := make(map[string][]byte)
 	for _, keyVaultObject := range keyVaultObjects {
-		klog.InfoS("fetching object from key vault", "objectName", keyVaultObject.ObjectName, "objectType", keyVaultObject.ObjectType, "keyvault", mc.keyvaultName, "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
+		klog.V(5).InfoS("fetching object from key vault", "objectName", keyVaultObject.ObjectName, "objectType", keyVaultObject.ObjectType, "keyvault", mc.keyvaultName, "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
 		if err := validateObjectFormat(keyVaultObject.ObjectFormat, keyVaultObject.ObjectType); err != nil {
 			return nil, nil, wrapObjectTypeError(err, keyVaultObject.ObjectType, keyVaultObject.ObjectName, keyVaultObject.ObjectVersion)
 		}
@@ -308,7 +308,7 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 
 		// these files will be returned to the CSI driver as part of gRPC response
 		files[fileName] = objectContent
-		klog.InfoS("added file to the gRPC response", "file", fileName, "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
+		klog.V(5).InfoS("added file to the gRPC response", "file", fileName, "pod", klog.ObjectRef{Namespace: podNamespace, Name: podName})
 	}
 
 	return files, objectVersionMap, nil
@@ -571,7 +571,7 @@ func setAzureEnvironmentFilePath(envFileName string) error {
 	if envFileName == "" {
 		return nil
 	}
-	klog.InfoS("setting AZURE_ENVIRONMENT_FILEPATH for custom cloud", "fileName", envFileName)
+	klog.V(5).InfoS("setting AZURE_ENVIRONMENT_FILEPATH for custom cloud", "fileName", envFileName)
 	return os.Setenv(azure.EnvironmentFilepathName, envFileName)
 }
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
 - Update `klog.InfoS` to `klog.V(5).InfoS`
 - Update makefile target `make image` as it's no longer available to `$(MAKE) container-all push-manifest`
<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**: #649 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
