### PR TITLE
fix: Add missing fullnameOverride to helm chart

### DIFF
--- a/manifest_staging/charts/csi-secrets-store-provider-azure/Chart.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: csi-secrets-store-provider-azure
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.0.1
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart to install the Secrets Store CSI Driver and the Azure Keyvault Provider inside a Kubernetes cluster.

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/_helpers.tpl
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/_helpers.tpl
@@ -12,11 +12,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "sscdpa.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/values.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/values.yaml
@@ -1,3 +1,6 @@
+nameOverride: ""
+fullnameOverride: ""
+
 # Values populated by Azure Arc K8s RP during the installation of the extension.
 Azure:
   proxySettings:


### PR DESCRIPTION
Signed-off-by: Nick Fisher <nxf5025@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
The fullnameOverride is documented in the README.md, but is not implemented as part of the helm chart helpers.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
