### PR TITLE
docs: add keyvault artificats setup for testing

### DIFF
--- a/docs/keyvault-test-setup.md
+++ b/docs/keyvault-test-setup.md
@@ -1,0 +1,65 @@
+# Commands for creating secrets, keys and certificates for testing
+
+```bash
+export KEYVAULT_NAME=<keyvault-name>
+export LOCATION=<location>
+export RESOURCE_GROUP=<resource-group>
+```
+
+## Create Key Vault
+
+```bash
+az keyvault create --resource-group "${RESOURCE_GROUP}" \
+   --location "${LOCATION}" \
+   --name "${KEYVAULT_NAME}" \
+   --sku premium
+```
+
+## Create the secrets
+
+```bash
+az keyvault secret set --vault-name $KEYVAULT_NAME --name secret1 --value test
+```
+
+## Create the keys
+
+### RSA Key
+
+```bash
+az keyvault key create --vault-name $KEYVAULT_NAME --name key1 --kty RSA --size 2048
+```
+
+### RSA-HSM Key
+
+```bash
+az keyvault key create --vault-name $KEYVAULT_NAME --name rsahsmkey1 --kty RSA-HSM --size 2048
+```
+
+### EC-HSM Key
+
+```bash
+az keyvault key create --vault-name $KEYVAULT_NAME --name echsmkey1 --kty EC-HSM --curve P-256
+```
+
+## Create the certificates
+
+The certificates are generated using [step-cli](https://smallstep.com/cli/) so the SAN can be specified.
+
+### PEM and PKCS12 certificates
+
+```bash
+step certificate create test.domain.com test.crt test.key --profile self-signed --subtle --san test.domain.com --kty RSA --not-after 86400h --no-password --insecure
+# export to pfx so we can import it into Azure Key Vault
+openssl pkcs12 -export -in test.crt -inkey test.key -out test.pfx -passout pass:
+az keyvault certificate import --vault-name $KEYVAULT_NAME --name pemcert1 --file test.pfx
+az keyvault certificate import --vault-name $KEYVAULT_NAME --name pkcs12cert1 --file test.pfx
+```
+
+### ECC certificates
+
+```bash
+step certificate create test.domain.com testec.crt testec.key --profile self-signed --subtle --san test.domain.com --kty EC --not-after 86400h --no-password --insecure
+# export to pfx so we can import it into Azure Key Vault
+openssl pkcs12 -export -in testec.crt -inkey testec.key -out testec.pfx -passout pass:
+az keyvault certificate import --vault-name $KEYVAULT_NAME --name ecccert1 --file testec.pfx
+```


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds instructions for keyvault setup and commands used to generate the test secret/key/certs

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
