### PR TITLE
chore: update website deploy workflow

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -1,13 +1,19 @@
-name: github pages
+name: generate_website
 
 on:
   push:
     branches:
       - master
+    paths:
+      - ".github/workflows/website.yaml"
+      - "website/**"
+
+permissions:
+  contents: write
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         with:
@@ -28,3 +34,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/public
+          destination_dir: ./docs

--- a/website/config.toml
+++ b/website/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://azure.github.io/secrets-store-csi-driver-provider-azure"
+baseURL = "https://azure.github.io/secrets-store-csi-driver-provider-azure/docs"
 title = "Azure Key Vault Provider for Secrets Store CSI Driver"
 
 enableRobotsTXT = true


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
part of #615 

- Updates gh workflow to publish the docs to `docs` directory in gh-pages

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
Validated here: https://aramase.github.io/secrets-store-csi-driver-provider-azure