### PR TITLE
docs: update chart repo to `https://azure.github.io/secrets-store-csi-driver-provider-azure/charts`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,8 +230,3 @@ promote-staging-manifest: #promote staging manifests to release dir
 	@cp -r manifest_staging/deployment .
 	@rm -rf charts/csi-secrets-store-provider-azure
 	@cp -r manifest_staging/charts/csi-secrets-store-provider-azure ./charts
-	@mkdir -p ./charts/tmp
-	@helm package ./charts/csi-secrets-store-provider-azure -d ./charts/tmp/
-	@helm repo index ./charts/tmp --url https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts --merge ./charts/index.yaml
-	@mv ./charts/tmp/* ./charts
-	@rm -rf ./charts/tmp

--- a/charts/csi-secrets-store-provider-azure/README.md
+++ b/charts/csi-secrets-store-provider-azure/README.md
@@ -27,8 +27,22 @@ Azure Key Vault provider for Secrets Store CSI driver allows you to get secret c
 | `0.2.1`            | `0.3.0`                          | `0.2.0`                          |
 | `1.0.0-rc.0`       | `1.0.0-rc.0`                     | `1.0.0-rc.0`                     |
 | `1.0.0`            | `1.0.0`                          | `1.0.0`                          |
+| `1.0.1`            | `1.0.1`                          | `1.0.1`                          |
 
 ## Installation
+
+> Note: The helm chart repository URL has changed from `https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts` to `https://azure.github.io/secrets-store-csi-driver-provider-azure/charts`.
+<details>
+<summary>Update helm chart repository if using the old URL</summary>
+
+Run the following commands to update your Helm chart repositories if using the old URL:
+
+```bash
+helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts --force-update
+helm repo update
+```
+
+</details>
 
 Quick start instructions for the setup and configuration of secrets-store-csi-driver and azure keyvault provider using Helm.
 
@@ -41,7 +55,7 @@ Quick start instructions for the setup and configuration of secrets-store-csi-dr
 - This chart installs the [secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) and the azure keyvault provider for the driver
 
 ```shell
-helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
+helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
 helm install csi-secrets-store-provider-azure/csi-secrets-store-provider-azure --generate-name
 ```
 

--- a/examples/kind/kind-demo.sh
+++ b/examples/kind/kind-demo.sh
@@ -5,7 +5,7 @@ CLIENT_SECRET=$2
 kind create cluster --name kind-csi-demo
 
 # install csi-secrets-store-provider-azure
-helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
+helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
 helm install csi-secrets-store-provider-azure/csi-secrets-store-provider-azure --generate-name
 
 # create secret in k8

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/README.md
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/README.md
@@ -27,8 +27,22 @@ Azure Key Vault provider for Secrets Store CSI driver allows you to get secret c
 | `0.2.1`            | `0.3.0`                          | `0.2.0`                          |
 | `1.0.0-rc.0`       | `1.0.0-rc.0`                     | `1.0.0-rc.0`                     |
 | `1.0.0`            | `1.0.0`                          | `1.0.0`                          |
+| `1.0.1`            | `1.0.1`                          | `1.0.1`                          |
 
 ## Installation
+
+> Note: The helm chart repository URL has changed from `https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts` to `https://azure.github.io/secrets-store-csi-driver-provider-azure/charts`.
+<details>
+<summary>Update helm chart repository if using the old URL</summary>
+
+Run the following commands to update your Helm chart repositories if using the old URL:
+
+```bash
+helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts --force-update
+helm repo update
+```
+
+</details>
 
 Quick start instructions for the setup and configuration of secrets-store-csi-driver and azure keyvault provider using Helm.
 
@@ -41,7 +55,7 @@ Quick start instructions for the setup and configuration of secrets-store-csi-dr
 - This chart installs the [secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) and the azure keyvault provider for the driver
 
 ```shell
-helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
+helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
 helm install csi-secrets-store-provider-azure/csi-secrets-store-provider-azure --generate-name
 ```
 

--- a/website/content/en/configurations/deploy-in-openshift.md
+++ b/website/content/en/configurations/deploy-in-openshift.md
@@ -12,7 +12,7 @@ description: >
 1. Install the Azure Keyvault provider for Secrets Store CSI Driver on Azure RedHat OpenShift run:
 
     ```bash
-    helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
+    helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
     helm install csi csi-secrets-store-provider-azure/csi-secrets-store-provider-azure --set linux.privileged=true
     ```
 

--- a/website/content/en/configurations/ingress-tls.md
+++ b/website/content/en/configurations/ingress-tls.md
@@ -43,7 +43,7 @@ az keyvault certificate import --vault-name $AKV_NAME -n $CERT_NAME -f $CERT_NAM
 Deploy the Azure Key Vault Provider and Secrets Store CSI Driver components:
 
 ```bash
-helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
+helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
 helm install csi csi-secrets-store-provider-azure/csi-secrets-store-provider-azure --set secrets-store-csi-driver.syncSecret.enabled=true
 ```
 

--- a/website/content/en/demos/standard-walkthrough/_index.md
+++ b/website/content/en/demos/standard-walkthrough/_index.md
@@ -27,7 +27,7 @@ export KEYVAULT_NAME=secret-store-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold
 Deploy the Azure Key Vault Provider and Secrets Store CSI Driver components:
 
 ```bash
-helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
+helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
 helm install csi csi-secrets-store-provider-azure/csi-secrets-store-provider-azure
 ```
 

--- a/website/content/en/getting-started/installation/_index.md
+++ b/website/content/en/getting-started/installation/_index.md
@@ -9,6 +9,12 @@ description: >
 
 ### Install the Secrets Store CSI Driver and the Azure Keyvault Provider
 
+{{% alert title="Note" color="info" %}}
+
+The helm chart repository URL has changed to `https://azure.github.io/secrets-store-csi-driver-provider-azure/charts`
+
+{{% /alert %}}
+
 #### Prerequisites
 
 Recommended Kubernetes version:
@@ -25,7 +31,7 @@ Azure Key Vault Provider for Secrets Store CSI Driver allows users to customize 
 > Recommended to use Helm3
 
 ```bash
-helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
+helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
 helm install csi csi-secrets-store-provider-azure/csi-secrets-store-provider-azure
 ```
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
part of #615 

- The helm charts have been moved to `https://azure.github.io/secrets-store-csi-driver-provider-azure/charts`. With this PR, we're updating the install instructions to use the new helm chart repository URL.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
