### PR TITLE
ci: fix shellcheck file paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ lint: $(TOOLS_DIR)/golangci-lint $(TOOLS_DIR)/misspell
 
 .PHONY: shellcheck
 shellcheck: $(SHELLCHECK)
-	$(SHELLCHECK) */*.sh
+	find . -name '*.sh' | xargs $(SHELLCHECK)
 
 .PHONY: unit-test
 unit-test:

--- a/examples/kind/kind-demo.sh
+++ b/examples/kind/kind-demo.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 CLIENT_ID=$1
 CLIENT_SECRET=$2
 
@@ -9,7 +11,8 @@ helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-s
 helm install csi-secrets-store-provider-azure/csi-secrets-store-provider-azure --generate-name
 
 # create secret in k8
-kubectl create secret generic secrets-store-creds --from-literal clientid=$CLIENT_ID --from-literal clientsecret=$CLIENT_SECRET
+kubectl create secret generic secrets-store-creds --from-literal clientid="$CLIENT_ID" --from-literal clientsecret="$CLIENT_SECRET"
+
 # label the secret
 kubectl label secret secrets-store-creds secrets-store.csi.k8s.io/used=true
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- `shellcheck */*.sh` doesn't check all the shell files in the repo. Changing to use `find` all files and then run shellcheck.
- Fixes errors

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
