### PR TITLE
test: enable workload identity test with deploy manifests

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -33,7 +33,7 @@ const (
 	tokenTypeBearer = "Bearer"
 	// For Azure AD Workload Identity, the audience recommended for use is
 	// "api://AzureADTokenExchange"
-	defaultTokenAudience = "api://AzureADTokenExchange" //nolint
+	DefaultTokenAudience = "api://AzureADTokenExchange" //nolint
 )
 
 var (
@@ -329,7 +329,7 @@ func ParseServiceAccountToken(saTokens string) (string, error) {
 	}
 	klog.V(5).InfoS("successfully unmarshaled service account tokens")
 	if tokens.APIAzureADTokenExchange.Token == "" {
-		return "", fmt.Errorf("token for audience %s not found", defaultTokenAudience)
+		return "", fmt.Errorf("token for audience %s not found", DefaultTokenAudience)
 	}
 	return tokens.APIAzureADTokenExchange.Token, nil
 }

--- a/test/e2e/workload_identity_test.go
+++ b/test/e2e/workload_identity_test.go
@@ -106,10 +106,6 @@ var _ = Describe("CSI inline volume test with workload identity", func() {
 		if !config.IsKindCluster {
 			Skip("test case currently supported for kind cluster only")
 		}
-		// the audience field is configurable only with helm charts
-		if !config.IsHelmTest {
-			Skip("test case currently supported for helm test only")
-		}
 
 		pod.WaitFor(pod.WaitForInput{
 			Getter:         kubeClient,


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Enables workload identity test with driver and provider deploy manifests

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
