### PR TITLE
test: enable workload identity test with soak clusters 

### DIFF
--- a/test/e2e/workload_identity_test.go
+++ b/test/e2e/workload_identity_test.go
@@ -103,8 +103,11 @@ var _ = Describe("CSI inline volume test with workload identity", func() {
 	})
 
 	It("should read secret, key from pod", func() {
-		if !config.IsKindCluster {
-			Skip("test case currently supported for kind cluster only")
+		if config.IsArcTest {
+			Skip("test is not supported in Arc cluster")
+		}
+		if !(config.IsKindCluster || config.IsSoakTest) {
+			Skip("test case currently supported for kind and soak cluster only")
 		}
 
 		pod.WaitFor(pod.WaitForInput{


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Enabling workload identity with soak clusters
  - Updated the soak clusters with `--enable-oidc-issuer`.
  - Setup federated identity credential with the issuer and <service account name, namespace>

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
