### PR TITLE
fix: update versions installed in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,18 +2,18 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-FROM golang:1.15
+FROM golang:1.17
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 # JQ Version
-ENV JQ_VERSION='1.5'
+ENV JQ_VERSION='1.6'
 # Helm Version
-ARG HELM_VERSION=3.0.2
+ARG HELM_VERSION=3.7.0
 #Kind Version
-ARG KIND_VERSION=0.8.1
+ARG KIND_VERSION=0.12.0
 # Kubernetes Version for Kubectl
-ARG KUBERNETES_VERSION=1.18.2
+ARG KUBERNETES_VERSION=1.22.2
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
@@ -58,15 +58,7 @@ RUN apt-get update \
   github.com/go-delve/delve/cmd/dlv@latest 2>&1 \
   #
   # Install Go tools w/o module support
-  && go get -v github.com/alecthomas/gometalinter 2>&1 \
-  #
-  # Install gocode-gomod
-  && go get -x -d github.com/stamblerre/gocode 2>&1 \
-  && go build -o gocode-gomod github.com/stamblerre/gocode \
-  && mv gocode-gomod $GOPATH/bin/ \
-  #
-  # Install golangci-lint
-  && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin 2>&1 \
+  && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest 2>&1 \
   #
   # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
   && groupadd --gid $USER_GID $USERNAME \


### PR DESCRIPTION
Updated versions:
- golang base container updated to 1.17
- jq updated to 1.6
- helm updated to 3.7.0
- kind updated to 0.12.0
- kubectl updated to 1.22.2

This also removes a few packages that were installed and are currently marked as deprecated where the replacements are packages we're already installing:
- gocode/gocod-mod is superseeded by gopls
- gometalinter is superseeded by golangci-lint

Additionally, golangci-lint is now installed via go install instead of curl-ing then sourcing the install script

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
When working on #834 I ran into some issues because the devcontainer was configured to use an older version of go than this project currently requires.

**Requirements**

- [x] squashed commits
- [x] included documentation (not applicable)
- [x] added unit tests and e2e tests (if applicable). (not applicable)


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
I've verified this works as I expect it to on both windows and macOS, I do not have a linux dev machine but I wouldn't expect any of these changes to break on linux.