### PR TITLE
chore: switch to upstream acr

### DIFF
--- a/.pipelines/templates/role-assignment.yaml
+++ b/.pipelines/templates/role-assignment.yaml
@@ -14,11 +14,5 @@ steps:
         ROLE_ASSIGNMENT_IDS+="${ID} "
       fi
 
-      # permission for ACR
-      if [[ -n "$(REGISTRY_NAME)" ]]; then
-        ID="$(az role assignment create --assignee-object-id "${ASSIGNEE_OBJECT_ID}" --assignee-principal-type "ServicePrincipal" --role "AcrPull" --scope "/subscriptions/$(SUBSCRIPTION_ID)/resourceGroups/k8sbuildci/providers/Microsoft.ContainerRegistry/registries/$(REGISTRY_NAME)" --query id -otsv)"
-        ROLE_ASSIGNMENT_IDS+="${ID} "
-      fi
-
       echo "##vso[task.setvariable variable=ROLE_ASSIGNMENT_IDS]${ROLE_ASSIGNMENT_IDS}"
     displayName: "Add role assignment"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ORG_PATH=github.com/Azure
 PROJECT_NAME := secrets-store-csi-driver-provider-azure
 REPO_PATH="$(ORG_PATH)/$(PROJECT_NAME)"
 
-REGISTRY_NAME ?= upstreamk8sci
+REGISTRY_NAME ?= upstream
 REPO_PREFIX ?= k8s/csi/secrets-store
 REGISTRY ?= $(REGISTRY_NAME).azurecr.io/$(REPO_PREFIX)
 IMAGE_VERSION ?= v1.1.0


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
Switching staging registry from using upstreamk8sci to upstream.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
