### PR TITLE
Fixing chart version number in chart docs

### DIFF
--- a/charts/csi-secrets-store-provider-azure/README.md
+++ b/charts/csi-secrets-store-provider-azure/README.md
@@ -30,7 +30,7 @@ Azure Key Vault provider for Secrets Store CSI driver allows you to get secret c
 | `1.0.1`            | `1.0.1`                          | `1.0.1`                          |
 | `1.1.0-rc.0`       | `1.1.0`                          | `1.1.0-rc.0`                     |
 | `1.1.0`            | `1.1.0`                          | `1.1.0`                          |
-| `1.1.0`            | `1.1.1`                          | `1.1.0`                          |
+| `1.1.1`            | `1.1.1`                          | `1.1.0`                          |
 
 ## Installation
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
Latest chart version is 1.1.1 not 1.1.0

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
