### PR TITLE
test: set -v=5 to get debug logs in e2e

### DIFF
--- a/test/e2e/framework/deploy/deploy.go
+++ b/test/e2e/framework/deploy/deploy.go
@@ -100,6 +100,9 @@ func InstallManifest(kubeconfigPath string, config *framework.Config) {
 			MountPath: "/etc/kubernetes/custom_environment.json",
 		})
 
+		// Configure higher log verbosity for debugging CI failures
+		ds.Spec.Template.Spec.Containers[0].Args = append(ds.Spec.Template.Spec.Containers[0].Args, "-v=5")
+
 		updatedDS, err := yaml.Marshal(ds)
 		Expect(err).To(BeNil())
 

--- a/test/e2e/framework/helm/helm.go
+++ b/test/e2e/framework/helm/helm.go
@@ -51,7 +51,7 @@ func Install(input InstallInput) {
 		fmt.Sprintf("--set=secrets-store-csi-driver.rotationPollInterval=30s"),
 		fmt.Sprintf("--set=secrets-store-csi-driver.syncSecret.enabled=true"),
 		fmt.Sprintf(`--set=secrets-store-csi-driver.tokenRequests[0].audience=api://AzureADTokenExchange`),
-		fmt.Sprintf("--set=logVerbosity=1"),
+		fmt.Sprintf("--set=logVerbosity=5"),
 		fmt.Sprintf("--set=linux.customUserAgent=csi-e2e"),
 		fmt.Sprintf("--set=windows.customUserAgent=csi-e2e"),
 		"--dependency-update",


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
