### PR TITLE
ci: remove kubernetes version 1.20 (EOL)

### DIFF
--- a/.pipelines/templates/e2e-test-kind.yaml
+++ b/.pipelines/templates/e2e-test-kind.yaml
@@ -13,29 +13,23 @@ jobs:
     - group: csi-secrets-store-e2e-kind
     strategy:
       matrix:
-        kind_v1_20_7_helm:
-          KIND_K8S_VERSION: v1.20.7
+        kind_v1_21_10_helm:
+          KIND_K8S_VERSION: v1.21.10
           IS_HELM_TEST: true
-        kind_v1_21_2_helm:
-          KIND_K8S_VERSION: v1.21.2
+        kind_v1_22_7_helm:
+          KIND_K8S_VERSION: v1.22.7
           IS_HELM_TEST: true
-        kind_v1_22_4_helm:
-          KIND_K8S_VERSION: v1.22.4
+        kind_v1_23_5_helm:
+          KIND_K8S_VERSION: v1.23.5
           IS_HELM_TEST: true
-        kind_v1_23_3_helm:
-          KIND_K8S_VERSION: v1.23.3
-          IS_HELM_TEST: true
-        kind_v1_20_7_deployment_manifest:
-          KIND_K8S_VERSION: v1.20.7
+        kind_v1_21_10_deployment_manifest:
+          KIND_K8S_VERSION: v1.21.10
           IS_HELM_TEST: false
-        kind_v1_21_2_deployment_manifest:
-          KIND_K8S_VERSION: v1.21.2
-          IS_HELM_TEST: false
-        kind_v1_22_4_deployment_manifest:
-          KIND_K8S_VERSION: v1.22.4
+        kind_v1_22_7_deployment_manifest:
+          KIND_K8S_VERSION: v1.22.7
           IS_HELM_TEST: false 
-        kind_v1_23_3_deployment_manifest:
-          KIND_K8S_VERSION: v1.23.3
+        kind_v1_23_5_deployment_manifest:
+          KIND_K8S_VERSION: v1.23.5
           IS_HELM_TEST: false
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,9 @@ BUILDX_BUILDER_NAME ?= img-builder
 STEP_CLI_VERSION=0.18.0
 
 # E2E test variables
-KIND_VERSION ?= 0.11.0
-KIND_K8S_VERSION ?= v1.22.4
-SHELLCHECK_VER ?= v0.7.2
+KIND_VERSION ?= 0.12.0
+KIND_K8S_VERSION ?= v1.23.5
+SHELLCHECK_VER ?= v0.8.0
 
 $(TOOLS_DIR)/golangci-lint: $(TOOLS_MOD_DIR)/go.mod $(TOOLS_MOD_DIR)/go.sum $(TOOLS_MOD_DIR)/tools.go
 	cd $(TOOLS_MOD_DIR) && \
@@ -237,9 +237,7 @@ e2e-kind-cleanup:
 	kind delete cluster --name kind
 
 .PHONY: helm-lint
-helm-lint:
-	# Download and install Helm
-	curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+helm-lint: install-helm
 	# install driver dep as helm 3.4.0 requires dependencies for helm lint
 	helm dep update charts/csi-secrets-store-provider-azure
 	helm dep update manifest_staging/charts/csi-secrets-store-provider-azure

--- a/website/content/en/_index.md
+++ b/website/content/en/_index.md
@@ -15,8 +15,8 @@ Azure Key Vault provider for [Secrets Store CSI Driver](https://github.com/kuber
 
 | Azure Key Vault Provider                                                                       | Compatible Kubernetes | `secrets-store.csi.x-k8s.io` Versions |
 | ---------------------------------------------------------------------------------------------- | --------------------- | ------------------------------------- |
-| [v1.0.0](https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.0.0) | 1.19+                 | `v1`, `v1alpha1`                      |
-| [v0.2.0](https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v0.2.0) | 1.19+                 | `v1alpha1`                            |
+| [v1.1.0](https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.1.0) | 1.21+                 | `v1`, `v1alpha1 [DEPRECATED]`         |
+| [v1.0.1](https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.0.1) | 1.21+                 | `v1alpha1`                            |
 
 For Secrets Store CSI Driver project status and supported versions, check the doc [here](https://secrets-store-csi-driver.sigs.k8s.io/#project-status)
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Update kind to `v0.12.0`
- Remove Kubernetes version 1.20 from docs and CI since it has reached EOL
- Update Kubernetes versions to latest in CI for supported releases

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
