### PR TITLE
chore: update to debian-base:bullseye-v1.2.0 for arc conformance

### DIFF
--- a/.pipelines/templates/scan-images.yaml
+++ b/.pipelines/templates/scan-images.yaml
@@ -1,8 +1,8 @@
 steps:
   - script: |
       # install trivy
-      wget https://github.com/aquasecurity/trivy/releases/download/v$(TRIVY_VERSION)/trivy_$(TRIVY_VERSION)_Linux-64bit.tar.gz
-      tar zxvf trivy_$(TRIVY_VERSION)_Linux-64bit.tar.gz
+      wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION:-0.24.4}/trivy_${TRIVY_VERSION:-0.24.4}_Linux-64bit.tar.gz
+      tar zxvf trivy_${TRIVY_VERSION:-0.24.4}_Linux-64bit.tar.gz
 
       # scan provider image
       export REGISTRY="e2e"
@@ -10,8 +10,8 @@ steps:
       OUTPUT_TYPE=docker make container arc-conformance-container
       # show all vulnerabilities in the logs
       ./trivy image "${REGISTRY}/provider-azure:${IMAGE_VERSION}"
-      ./trivy image --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/provider-azure:${IMAGE_VERSION}" || exit 1
+      ./trivy image --vuln-type os --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/provider-azure:${IMAGE_VERSION}" || exit 1
       
       ./trivy image "${REGISTRY}/provider-azure-arc-conformance:${IMAGE_VERSION}-linux-amd64"
-      ./trivy image --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/provider-azure-arc-conformance:${IMAGE_VERSION}-linux-amd64" || exit 1
+      ./trivy image --vuln-type os --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "${REGISTRY}/provider-azure-arc-conformance:${IMAGE_VERSION}-linux-amd64" || exit 1
     displayName: "Scan images for vulnerability"

--- a/arc/conformance/plugin/Dockerfile
+++ b/arc/conformance/plugin/Dockerfile
@@ -2,7 +2,7 @@ ARG STEP_CLI_VERSION=0.18.0
 ARG STEP_CLI_IMAGE=smallstep/step-cli:${STEP_CLI_VERSION}
 FROM $STEP_CLI_IMAGE as step-cli
 
-FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
+FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.2.0
 ARG KUBE_VERSION=v1.21.2
 ARG TARGETARCH
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
