### PR TITLE
refactor: add functions to get parameters and add constants

### DIFF
--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/auth"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/version"
 )
 
@@ -429,19 +430,19 @@ func TestGetContentBytes(t *testing.T) {
 func TestFormatKeyVaultObject(t *testing.T) {
 	cases := []struct {
 		desc                   string
-		keyVaultObject         KeyVaultObject
-		expectedKeyVaultObject KeyVaultObject
+		keyVaultObject         types.KeyVaultObject
+		expectedKeyVaultObject types.KeyVaultObject
 	}{
 		{
 			desc: "leading and trailing whitespace trimmed from all fields",
-			keyVaultObject: KeyVaultObject{
+			keyVaultObject: types.KeyVaultObject{
 				ObjectName:     "secret1     ",
 				ObjectVersion:  "",
 				ObjectEncoding: "base64   ",
 				ObjectType:     "  secret",
 				ObjectAlias:    "",
 			},
-			expectedKeyVaultObject: KeyVaultObject{
+			expectedKeyVaultObject: types.KeyVaultObject{
 				ObjectName:     "secret1",
 				ObjectVersion:  "",
 				ObjectEncoding: "base64",
@@ -451,14 +452,14 @@ func TestFormatKeyVaultObject(t *testing.T) {
 		},
 		{
 			desc: "no data loss for already sanitized object",
-			keyVaultObject: KeyVaultObject{
+			keyVaultObject: types.KeyVaultObject{
 				ObjectName:     "secret1",
 				ObjectVersion:  "version1",
 				ObjectEncoding: "base64",
 				ObjectType:     "secret",
 				ObjectAlias:    "alias",
 			},
-			expectedKeyVaultObject: KeyVaultObject{
+			expectedKeyVaultObject: types.KeyVaultObject{
 				ObjectName:     "secret1",
 				ObjectVersion:  "version1",
 				ObjectEncoding: "base64",

--- a/pkg/provider/types/constants.go
+++ b/pkg/provider/types/constants.go
@@ -1,0 +1,49 @@
+package types
+
+const (
+	// VaultObjectTypeSecret secret vault object type
+	VaultObjectTypeSecret = "secret"
+	// VaultObjectTypeKey key vault object type
+	VaultObjectTypeKey = "key"
+	// VaultObjectTypeCertificate certificate vault object type
+	VaultObjectTypeCertificate = "cert"
+
+	CertTypePem = "application/x-pem-file"
+	CertTypePfx = "application/x-pkcs12"
+
+	CertificateType = "CERTIFICATE"
+
+	ObjectFormatPEM = "pem"
+	ObjectFormatPFX = "pfx"
+
+	ObjectEncodingHex    = "hex"
+	ObjectEncodingBase64 = "base64"
+	ObjectEncodingUtf8   = "utf-8"
+
+	// pod identity NMI port
+	PodIdentityNMIPort = "2579"
+
+	CSIAttributePodName              = "csi.storage.k8s.io/pod.name"
+	CSIAttributePodNamespace         = "csi.storage.k8s.io/pod.namespace"
+	CSIAttributeServiceAccountTokens = "csi.storage.k8s.io/serviceAccount.tokens" // nolint
+
+	// KeyVaultNameParameter is the name of the key vault name parameter
+	KeyVaultNameParameter = "keyvaultName"
+	// CloudNameParameter is the name of the cloud name parameter
+	CloudNameParameter = "cloudName"
+	// UsePodIdentityParameter is the name of the use pod identity parameter
+	UsePodIdentityParameter = "usePodIdentity"
+	// UseVMManagedIdentityParameter is the name of the use VM managed identity parameter
+	UseVMManagedIdentityParameter = "useVMManagedIdentity"
+	// UserAssignedIdentityIDParameter is the name of the user assigned identity ID parameter
+	UserAssignedIdentityIDParameter = "userAssignedIdentityID"
+	// TenantIDParameter is the name of the tenant ID parameter
+	TenantIDParameter = "tenantId"
+	// CloudEnvFileNameParameter is the name of the cloud env file name parameter
+	CloudEnvFileNameParameter = "cloudEnvFileName"
+	// ClientIDParameter is the name of the client ID parameter
+	// This clientID is used for workload identity
+	ClientIDParameter = "clientID"
+	// ObjectsParameter is the name of the objects parameter
+	ObjectsParameter = "objects"
+)

--- a/pkg/provider/types/parameters.go
+++ b/pkg/provider/types/parameters.go
@@ -1,0 +1,118 @@
+package types
+
+import (
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+// KeyVaultObject holds keyvault object related config
+type KeyVaultObject struct {
+	// the name of the Azure Key Vault objects
+	ObjectName string `json:"objectName" yaml:"objectName"`
+	// the filename the object will be written to
+	ObjectAlias string `json:"objectAlias" yaml:"objectAlias"`
+	// the version of the Azure Key Vault objects
+	ObjectVersion string `json:"objectVersion" yaml:"objectVersion"`
+	// the type of the Azure Key Vault objects
+	ObjectType string `json:"objectType" yaml:"objectType"`
+	// the format of the Azure Key Vault objects
+	// supported formats are PEM, PFX
+	ObjectFormat string `json:"objectFormat" yaml:"objectFormat"`
+	// The encoding of the object in KeyVault
+	// Supported encodings are Base64, Hex, Utf-8
+	ObjectEncoding string `json:"objectEncoding" yaml:"objectEncoding"`
+	// FilePermission is the file permissions
+	FilePermission string `json:"filePermission" yaml:"filePermission"`
+}
+
+// SecretFile holds content and metadata of a secret file that is sent
+// back to the driver
+type SecretFile struct {
+	Content  []byte
+	Path     string
+	FileMode int32
+	UID      string
+	Version  string
+}
+
+// StringArray holds a list of strings
+type StringArray struct {
+	Array []string `json:"array" yaml:"array"`
+}
+
+// GetKeyVaultName returns the key vault name
+func GetKeyVaultName(parameters map[string]string) string {
+	return strings.TrimSpace(parameters[KeyVaultNameParameter])
+}
+
+// GetCloudName returns the cloud name
+func GetCloudName(parameters map[string]string) string {
+	return strings.TrimSpace(parameters[CloudNameParameter])
+}
+
+// GetUsePodIdentity returns if pod identity is enabled
+func GetUsePodIdentity(parameters map[string]string) (bool, error) {
+	str := strings.TrimSpace(parameters[UsePodIdentityParameter])
+	if str == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(str)
+}
+
+// GetUseVMManagedIdentity returns if VM managed identity is enabled
+func GetUseVMManagedIdentity(parameters map[string]string) (bool, error) {
+	str := strings.TrimSpace(parameters[UseVMManagedIdentityParameter])
+	if str == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(str)
+}
+
+// GetUserAssignedIdentityID returns the user assigned identity ID
+func GetUserAssignedIdentityID(parameters map[string]string) string {
+	return strings.TrimSpace(parameters[UserAssignedIdentityIDParameter])
+}
+
+// GetTenantID returns the tenant ID
+func GetTenantID(parameters map[string]string) string {
+	return strings.TrimSpace(parameters[TenantIDParameter])
+}
+
+// GetCloudEnvFileName returns the cloud env file name
+func GetCloudEnvFileName(parameters map[string]string) string {
+	return strings.TrimSpace(parameters[CloudEnvFileNameParameter])
+}
+
+// GetPodName returns the pod name
+func GetPodName(parameters map[string]string) string {
+	return strings.TrimSpace(parameters[CSIAttributePodName])
+}
+
+// GetPodNamespace returns the pod namespace
+func GetPodNamespace(parameters map[string]string) string {
+	return strings.TrimSpace(parameters[CSIAttributePodNamespace])
+}
+
+// GetClientID returns the client ID
+func GetClientID(parameters map[string]string) string {
+	return strings.TrimSpace(parameters[ClientIDParameter])
+}
+
+// GetServiceAccountTokens returns the service account tokens
+func GetServiceAccountTokens(parameters map[string]string) string {
+	return strings.TrimSpace(parameters[CSIAttributeServiceAccountTokens])
+}
+
+// GetObjects returns the key vault objects
+func GetObjects(parameters map[string]string) string {
+	return strings.TrimSpace(parameters[ObjectsParameter])
+}
+
+// GetObjectsArray returns the key vault objects array
+func GetObjectsArray(objects string) (StringArray, error) {
+	var a StringArray
+	err := yaml.Unmarshal([]byte(objects), &a)
+	return a, err
+}

--- a/pkg/provider/types/parameters.go
+++ b/pkg/provider/types/parameters.go
@@ -7,41 +7,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// KeyVaultObject holds keyvault object related config
-type KeyVaultObject struct {
-	// the name of the Azure Key Vault objects
-	ObjectName string `json:"objectName" yaml:"objectName"`
-	// the filename the object will be written to
-	ObjectAlias string `json:"objectAlias" yaml:"objectAlias"`
-	// the version of the Azure Key Vault objects
-	ObjectVersion string `json:"objectVersion" yaml:"objectVersion"`
-	// the type of the Azure Key Vault objects
-	ObjectType string `json:"objectType" yaml:"objectType"`
-	// the format of the Azure Key Vault objects
-	// supported formats are PEM, PFX
-	ObjectFormat string `json:"objectFormat" yaml:"objectFormat"`
-	// The encoding of the object in KeyVault
-	// Supported encodings are Base64, Hex, Utf-8
-	ObjectEncoding string `json:"objectEncoding" yaml:"objectEncoding"`
-	// FilePermission is the file permissions
-	FilePermission string `json:"filePermission" yaml:"filePermission"`
-}
-
-// SecretFile holds content and metadata of a secret file that is sent
-// back to the driver
-type SecretFile struct {
-	Content  []byte
-	Path     string
-	FileMode int32
-	UID      string
-	Version  string
-}
-
-// StringArray holds a list of strings
-type StringArray struct {
-	Array []string `json:"array" yaml:"array"`
-}
-
 // GetKeyVaultName returns the key vault name
 func GetKeyVaultName(parameters map[string]string) string {
 	return strings.TrimSpace(parameters[KeyVaultNameParameter])

--- a/pkg/provider/types/parameters_test.go
+++ b/pkg/provider/types/parameters_test.go
@@ -14,14 +14,21 @@ func TestGetKeyVaultName(t *testing.T) {
 		{
 			name: "empty",
 			parameters: map[string]string{
-				"keyvaultName": "",
+				KeyVaultNameParameter: "",
 			},
 			expected: "",
 		},
 		{
 			name: "not empty",
 			parameters: map[string]string{
-				"keyvaultName": "test",
+				KeyVaultNameParameter: "test",
+			},
+			expected: "test",
+		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				KeyVaultNameParameter: " test ",
 			},
 			expected: "test",
 		},
@@ -46,14 +53,21 @@ func TestGetCloudName(t *testing.T) {
 		{
 			name: "empty",
 			parameters: map[string]string{
-				"cloudName": "",
+				CloudNameParameter: "",
 			},
 			expected: "",
 		},
 		{
 			name: "not empty",
 			parameters: map[string]string{
-				"cloudName": "test",
+				CloudNameParameter: "test",
+			},
+			expected: "test",
+		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				CloudNameParameter: " test ",
 			},
 			expected: "test",
 		},
@@ -78,37 +92,44 @@ func TestGetUsePodIdentity(t *testing.T) {
 		{
 			name: "empty",
 			parameters: map[string]string{
-				"usePodIdentity": "",
+				UsePodIdentityParameter: "",
 			},
 			expected: false,
 		},
 		{
 			name: "set to true",
 			parameters: map[string]string{
-				"usePodIdentity": "true",
+				UsePodIdentityParameter: "true",
 			},
 			expected: true,
 		},
 		{
 			name: "set to false",
 			parameters: map[string]string{
-				"usePodIdentity": "false",
+				UsePodIdentityParameter: "false",
 			},
 			expected: false,
 		},
 		{
 			name: "set to True",
 			parameters: map[string]string{
-				"usePodIdentity": "True",
+				UsePodIdentityParameter: "True",
 			},
 			expected: true,
 		},
 		{
 			name: "set to False",
 			parameters: map[string]string{
-				"usePodIdentity": "False",
+				UsePodIdentityParameter: "False",
 			},
 			expected: false,
+		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				UsePodIdentityParameter: " true ",
+			},
+			expected: true,
 		},
 	}
 
@@ -127,7 +148,7 @@ func TestGetUsePodIdentity(t *testing.T) {
 
 func TestGetUsePodIdentityError(t *testing.T) {
 	parameters := map[string]string{
-		"usePodIdentity": "test",
+		UsePodIdentityParameter: "test",
 	}
 	if _, err := GetUsePodIdentity(parameters); err == nil {
 		t.Errorf("GetUsePodIdentity() error = nil, expected error")
@@ -143,37 +164,44 @@ func TestGetUseVMManagedIdentity(t *testing.T) {
 		{
 			name: "empty",
 			parameters: map[string]string{
-				"useVMManagedIdentity": "",
+				UseVMManagedIdentityParameter: "",
 			},
 			expected: false,
 		},
 		{
 			name: "set to true",
 			parameters: map[string]string{
-				"useVMManagedIdentity": "true",
+				UseVMManagedIdentityParameter: "true",
 			},
 			expected: true,
 		},
 		{
 			name: "set to false",
 			parameters: map[string]string{
-				"useVMManagedIdentity": "false",
+				UseVMManagedIdentityParameter: "false",
 			},
 			expected: false,
 		},
 		{
 			name: "set to True",
 			parameters: map[string]string{
-				"useVMManagedIdentity": "True",
+				UseVMManagedIdentityParameter: "True",
 			},
 			expected: true,
 		},
 		{
 			name: "set to False",
 			parameters: map[string]string{
-				"useVMManagedIdentity": "False",
+				UseVMManagedIdentityParameter: "False",
 			},
 			expected: false,
+		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				UseVMManagedIdentityParameter: " true ",
+			},
+			expected: true,
 		},
 	}
 
@@ -192,7 +220,7 @@ func TestGetUseVMManagedIdentity(t *testing.T) {
 
 func TestGetUseVMManagedIdentityError(t *testing.T) {
 	parameters := map[string]string{
-		"useVMManagedIdentity": "test",
+		UseVMManagedIdentityParameter: "test",
 	}
 	if _, err := GetUseVMManagedIdentity(parameters); err == nil {
 		t.Errorf("GetUseVMManagedIdentity() error = nil, expected error")
@@ -208,14 +236,21 @@ func TestGetUserAssignedIdentityID(t *testing.T) {
 		{
 			name: "empty",
 			parameters: map[string]string{
-				"userAssignedIdentityID": "",
+				UserAssignedIdentityIDParameter: "",
 			},
 			expected: "",
 		},
 		{
 			name: "not empty",
 			parameters: map[string]string{
-				"userAssignedIdentityID": "test",
+				UserAssignedIdentityIDParameter: "test",
+			},
+			expected: "test",
+		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				UserAssignedIdentityIDParameter: " test ",
 			},
 			expected: "test",
 		},
@@ -240,14 +275,21 @@ func TestGetTenantID(t *testing.T) {
 		{
 			name: "empty",
 			parameters: map[string]string{
-				"tenantId": "",
+				TenantIDParameter: "",
 			},
 			expected: "",
 		},
 		{
 			name: "not empty",
 			parameters: map[string]string{
-				"tenantId": "test",
+				TenantIDParameter: "test",
+			},
+			expected: "test",
+		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				TenantIDParameter: " test ",
 			},
 			expected: "test",
 		},
@@ -272,14 +314,21 @@ func TestGetCloudEnvFileName(t *testing.T) {
 		{
 			name: "empty",
 			parameters: map[string]string{
-				"cloudEnvFileName": "",
+				CloudEnvFileNameParameter: "",
 			},
 			expected: "",
 		},
 		{
 			name: "not empty",
 			parameters: map[string]string{
-				"cloudEnvFileName": "test",
+				CloudEnvFileNameParameter: "test",
+			},
+			expected: "test",
+		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				CloudEnvFileNameParameter: " test ",
 			},
 			expected: "test",
 		},
@@ -315,6 +364,13 @@ func TestGetPodName(t *testing.T) {
 			},
 			expected: "test",
 		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				CSIAttributePodName: " test ",
+			},
+			expected: "test",
+		},
 	}
 
 	for _, test := range tests {
@@ -344,6 +400,13 @@ func TestGetPodNamespace(t *testing.T) {
 			name: "not empty",
 			parameters: map[string]string{
 				CSIAttributePodNamespace: "test",
+			},
+			expected: "test",
+		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				CSIAttributePodNamespace: " test ",
 			},
 			expected: "test",
 		},
@@ -379,6 +442,13 @@ func TestGetClientID(t *testing.T) {
 			},
 			expected: "test",
 		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				"clientID": " test ",
+			},
+			expected: "test",
+		},
 	}
 
 	for _, test := range tests {
@@ -411,6 +481,13 @@ func TestGetServiceAccountTokens(t *testing.T) {
 			},
 			expected: "test",
 		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				CSIAttributeServiceAccountTokens: " test ",
+			},
+			expected: "test",
+		},
 	}
 
 	for _, test := range tests {
@@ -432,14 +509,21 @@ func TestGetObjects(t *testing.T) {
 		{
 			name: "empty",
 			parameters: map[string]string{
-				"objects": "",
+				ObjectsParameter: "",
 			},
 			expected: "",
 		},
 		{
 			name: "not empty",
 			parameters: map[string]string{
-				"objects": "test",
+				ObjectsParameter: "test",
+			},
+			expected: "test",
+		},
+		{
+			name: "trim spaces",
+			parameters: map[string]string{
+				ObjectsParameter: " test ",
 			},
 			expected: "test",
 		},

--- a/pkg/provider/types/parameters_test.go
+++ b/pkg/provider/types/parameters_test.go
@@ -1,0 +1,499 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetKeyVaultName(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   string
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				"keyvaultName": "",
+			},
+			expected: "",
+		},
+		{
+			name: "not empty",
+			parameters: map[string]string{
+				"keyvaultName": "test",
+			},
+			expected: "test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetKeyVaultName(test.parameters)
+			if actual != test.expected {
+				t.Errorf("GetKeyVaultName() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetCloudName(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   string
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				"cloudName": "",
+			},
+			expected: "",
+		},
+		{
+			name: "not empty",
+			parameters: map[string]string{
+				"cloudName": "test",
+			},
+			expected: "test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetCloudName(test.parameters)
+			if actual != test.expected {
+				t.Errorf("GetCloudName() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetUsePodIdentity(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   bool
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				"usePodIdentity": "",
+			},
+			expected: false,
+		},
+		{
+			name: "set to true",
+			parameters: map[string]string{
+				"usePodIdentity": "true",
+			},
+			expected: true,
+		},
+		{
+			name: "set to false",
+			parameters: map[string]string{
+				"usePodIdentity": "false",
+			},
+			expected: false,
+		},
+		{
+			name: "set to True",
+			parameters: map[string]string{
+				"usePodIdentity": "True",
+			},
+			expected: true,
+		},
+		{
+			name: "set to False",
+			parameters: map[string]string{
+				"usePodIdentity": "False",
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := GetUsePodIdentity(test.parameters)
+			if err != nil {
+				t.Errorf("GetUsePodIdentity() error = %v, expected nil", err)
+			}
+			if actual != test.expected {
+				t.Errorf("GetUsePodIdentity() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetUsePodIdentityError(t *testing.T) {
+	parameters := map[string]string{
+		"usePodIdentity": "test",
+	}
+	if _, err := GetUsePodIdentity(parameters); err == nil {
+		t.Errorf("GetUsePodIdentity() error = nil, expected error")
+	}
+}
+
+func TestGetUseVMManagedIdentity(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   bool
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				"useVMManagedIdentity": "",
+			},
+			expected: false,
+		},
+		{
+			name: "set to true",
+			parameters: map[string]string{
+				"useVMManagedIdentity": "true",
+			},
+			expected: true,
+		},
+		{
+			name: "set to false",
+			parameters: map[string]string{
+				"useVMManagedIdentity": "false",
+			},
+			expected: false,
+		},
+		{
+			name: "set to True",
+			parameters: map[string]string{
+				"useVMManagedIdentity": "True",
+			},
+			expected: true,
+		},
+		{
+			name: "set to False",
+			parameters: map[string]string{
+				"useVMManagedIdentity": "False",
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := GetUseVMManagedIdentity(test.parameters)
+			if err != nil {
+				t.Errorf("GetUseVMManagedIdentity() error = %v, expected nil", err)
+			}
+			if actual != test.expected {
+				t.Errorf("GetUseVMManagedIdentity() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetUseVMManagedIdentityError(t *testing.T) {
+	parameters := map[string]string{
+		"useVMManagedIdentity": "test",
+	}
+	if _, err := GetUseVMManagedIdentity(parameters); err == nil {
+		t.Errorf("GetUseVMManagedIdentity() error = nil, expected error")
+	}
+}
+
+func TestGetUserAssignedIdentityID(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   string
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				"userAssignedIdentityID": "",
+			},
+			expected: "",
+		},
+		{
+			name: "not empty",
+			parameters: map[string]string{
+				"userAssignedIdentityID": "test",
+			},
+			expected: "test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetUserAssignedIdentityID(test.parameters)
+			if actual != test.expected {
+				t.Errorf("GetUserAssignedIdentityID() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetTenantID(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   string
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				"tenantId": "",
+			},
+			expected: "",
+		},
+		{
+			name: "not empty",
+			parameters: map[string]string{
+				"tenantId": "test",
+			},
+			expected: "test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetTenantID(test.parameters)
+			if actual != test.expected {
+				t.Errorf("GetTenantID() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetCloudEnvFileName(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   string
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				"cloudEnvFileName": "",
+			},
+			expected: "",
+		},
+		{
+			name: "not empty",
+			parameters: map[string]string{
+				"cloudEnvFileName": "test",
+			},
+			expected: "test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetCloudEnvFileName(test.parameters)
+			if actual != test.expected {
+				t.Errorf("GetCloudEnvFileName() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetPodName(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   string
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				CSIAttributePodName: "",
+			},
+			expected: "",
+		},
+		{
+			name: "not empty",
+			parameters: map[string]string{
+				CSIAttributePodName: "test",
+			},
+			expected: "test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetPodName(test.parameters)
+			if actual != test.expected {
+				t.Errorf("GetPodName() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetPodNamespace(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   string
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				CSIAttributePodNamespace: "",
+			},
+			expected: "",
+		},
+		{
+			name: "not empty",
+			parameters: map[string]string{
+				CSIAttributePodNamespace: "test",
+			},
+			expected: "test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetPodNamespace(test.parameters)
+			if actual != test.expected {
+				t.Errorf("GetPodNamespace() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetClientID(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   string
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				"clientID": "",
+			},
+			expected: "",
+		},
+		{
+			name: "not empty",
+			parameters: map[string]string{
+				"clientID": "test",
+			},
+			expected: "test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetClientID(test.parameters)
+			if actual != test.expected {
+				t.Errorf("GetClientID() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetServiceAccountTokens(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   string
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				CSIAttributeServiceAccountTokens: "",
+			},
+			expected: "",
+		},
+		{
+			name: "not empty",
+			parameters: map[string]string{
+				CSIAttributeServiceAccountTokens: "test",
+			},
+			expected: "test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetServiceAccountTokens(test.parameters)
+			if actual != test.expected {
+				t.Errorf("GetServiceAccountTokens() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetObjects(t *testing.T) {
+	tests := []struct {
+		name       string
+		parameters map[string]string
+		expected   string
+	}{
+		{
+			name: "empty",
+			parameters: map[string]string{
+				"objects": "",
+			},
+			expected: "",
+		},
+		{
+			name: "not empty",
+			parameters: map[string]string{
+				"objects": "test",
+			},
+			expected: "test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := GetObjects(test.parameters)
+			if actual != test.expected {
+				t.Errorf("GetObjects() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetObjectsArray(t *testing.T) {
+	tests := []struct {
+		name     string
+		objects  string
+		expected StringArray
+	}{
+		{
+			name:     "empty",
+			objects:  "",
+			expected: StringArray{},
+		},
+		{
+			name:    "valid yaml",
+			objects: "array:\n- |\n  filePermission: \"\"\n  objectAlias: \"\"\n  objectEncoding: \"\"\n  objectFormat: \"\"\n  objectName: secret1\n  objectType: cert\n  objectVersion: \"\"\n- |\n  filePermission: \"\"\n  objectAlias: \"\"\n  objectEncoding: \"\"\n  objectFormat: \"\"\n  objectName: secret2\n  objectType: cert\n  objectVersion: \"\"\n",
+			expected: StringArray{
+				Array: []string{
+					"filePermission: \"\"\nobjectAlias: \"\"\nobjectEncoding: \"\"\nobjectFormat: \"\"\nobjectName: secret1\nobjectType: cert\nobjectVersion: \"\"\n",
+					"filePermission: \"\"\nobjectAlias: \"\"\nobjectEncoding: \"\"\nobjectFormat: \"\"\nobjectName: secret2\nobjectType: cert\nobjectVersion: \"\"\n",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := GetObjectsArray(test.objects)
+			if err != nil {
+				t.Errorf("GetObjectsArray() error = %v", err)
+			}
+			if !reflect.DeepEqual(actual, test.expected) {
+				t.Errorf("GetObjectsArray() = %v, expected %v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestGetObjectsArrayError(t *testing.T) {
+	objects := "invalid"
+	if _, err := GetObjectsArray(objects); err == nil {
+		t.Errorf("GetObjectsArray() error is nil, expected error")
+	}
+}

--- a/pkg/provider/types/types.go
+++ b/pkg/provider/types/types.go
@@ -47,3 +47,38 @@ const (
 	// ObjectsParameter is the name of the objects parameter
 	ObjectsParameter = "objects"
 )
+
+// KeyVaultObject holds keyvault object related config
+type KeyVaultObject struct {
+	// the name of the Azure Key Vault objects
+	ObjectName string `json:"objectName" yaml:"objectName"`
+	// the filename the object will be written to
+	ObjectAlias string `json:"objectAlias" yaml:"objectAlias"`
+	// the version of the Azure Key Vault objects
+	ObjectVersion string `json:"objectVersion" yaml:"objectVersion"`
+	// the type of the Azure Key Vault objects
+	ObjectType string `json:"objectType" yaml:"objectType"`
+	// the format of the Azure Key Vault objects
+	// supported formats are PEM, PFX
+	ObjectFormat string `json:"objectFormat" yaml:"objectFormat"`
+	// The encoding of the object in KeyVault
+	// Supported encodings are Base64, Hex, Utf-8
+	ObjectEncoding string `json:"objectEncoding" yaml:"objectEncoding"`
+	// FilePermission is the file permissions
+	FilePermission string `json:"filePermission" yaml:"filePermission"`
+}
+
+// SecretFile holds content and metadata of a secret file that is sent
+// back to the driver
+type SecretFile struct {
+	Content  []byte
+	Path     string
+	FileMode int32
+	UID      string
+	Version  string
+}
+
+// StringArray holds a list of strings
+type StringArray struct {
+	Array []string `json:"array" yaml:"array"`
+}

--- a/test/e2e/auto_rotation_test.go
+++ b/test/e2e/auto_rotation_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/exec"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/helm"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/namespace"
@@ -76,14 +76,14 @@ var _ = Describe("Test auto rotation of mount contents and K8s secrets", func() 
 			Expect(err).To(BeNil())
 		}()
 
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: secretName,
-				ObjectType: provider.VaultObjectTypeSecret,
+				ObjectType: types.VaultObjectTypeSecret,
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -114,11 +114,11 @@ var _ = Describe("Test auto rotation of mount contents and K8s secrets", func() 
 					},
 				},
 				Parameters: map[string]string{
-					"keyvaultName":         config.KeyvaultName,
-					"tenantId":             config.TenantID,
-					"objects":              string(objects),
-					"usePodIdentity":       "false",
-					"useVMManagedIdentity": "false",
+					types.KeyVaultNameParameter:         config.KeyvaultName,
+					types.TenantIDParameter:             config.TenantID,
+					types.ObjectsParameter:              string(objects),
+					types.UsePodIdentityParameter:       "false",
+					types.UseVMManagedIdentityParameter: "false",
 				},
 			},
 		})
@@ -195,14 +195,14 @@ var _ = Describe("Test auto rotation of mount contents and K8s secrets", func() 
 			Expect(err).To(BeNil())
 		}()
 
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: secretName,
-				ObjectType: provider.VaultObjectTypeSecret,
+				ObjectType: types.VaultObjectTypeSecret,
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -233,12 +233,12 @@ var _ = Describe("Test auto rotation of mount contents and K8s secrets", func() 
 					},
 				},
 				Parameters: map[string]string{
-					"keyvaultName":           config.KeyvaultName,
-					"tenantId":               config.TenantID,
-					"objects":                string(objects),
-					"usePodIdentity":         "false",
-					"useVMManagedIdentity":   "true",
-					"userAssignedIdentityID": config.UserAssignedIdentityID,
+					types.KeyVaultNameParameter:           config.KeyvaultName,
+					types.TenantIDParameter:               config.TenantID,
+					types.ObjectsParameter:                string(objects),
+					types.UsePodIdentityParameter:         "false",
+					types.UseVMManagedIdentityParameter:   "true",
+					types.UserAssignedIdentityIDParameter: config.UserAssignedIdentityID,
 				},
 			},
 		})
@@ -317,14 +317,14 @@ var _ = Describe("Test auto rotation of mount contents and K8s secrets", func() 
 			Expect(err).To(BeNil())
 		}()
 
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: secretName,
-				ObjectType: provider.VaultObjectTypeSecret,
+				ObjectType: types.VaultObjectTypeSecret,
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -355,11 +355,11 @@ var _ = Describe("Test auto rotation of mount contents and K8s secrets", func() 
 					},
 				},
 				Parameters: map[string]string{
-					"keyvaultName":         config.KeyvaultName,
-					"tenantId":             config.TenantID,
-					"objects":              string(objects),
-					"usePodIdentity":       "true",
-					"useVMManagedIdentity": "false",
+					types.KeyVaultNameParameter:         config.KeyvaultName,
+					types.TenantIDParameter:             config.TenantID,
+					types.ObjectsParameter:              string(objects),
+					types.UsePodIdentityParameter:       "true",
+					types.UseVMManagedIdentityParameter: "false",
 				},
 			},
 		})

--- a/test/e2e/certificates_test.go
+++ b/test/e2e/certificates_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"strings"
 
-	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/certificates"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/exec"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/namespace"
@@ -46,64 +46,64 @@ var _ = Describe("When fetching certificates and private key from Key Vault", fu
 			Labels:    map[string]string{"secrets-store.csi.k8s.io/used": "true"},
 		})
 
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: "pemcert1",
-				ObjectType: provider.VaultObjectTypeCertificate,
+				ObjectType: types.VaultObjectTypeCertificate,
 			},
 			{
 				ObjectName: "pkcs12cert1",
-				ObjectType: provider.VaultObjectTypeCertificate,
+				ObjectType: types.VaultObjectTypeCertificate,
 			},
 			{
 				ObjectName: "ecccert1",
-				ObjectType: provider.VaultObjectTypeCertificate,
+				ObjectType: types.VaultObjectTypeCertificate,
 			},
 			{
 				ObjectName:  "pemcert1",
-				ObjectType:  provider.VaultObjectTypeKey,
+				ObjectType:  types.VaultObjectTypeKey,
 				ObjectAlias: "pemcert1-pub-key",
 			},
 			{
 				ObjectName:  "pkcs12cert1",
-				ObjectType:  provider.VaultObjectTypeKey,
+				ObjectType:  types.VaultObjectTypeKey,
 				ObjectAlias: "pkcs12cert1-pub-key",
 			},
 			{
 				ObjectName:  "ecccert1",
-				ObjectType:  provider.VaultObjectTypeKey,
+				ObjectType:  types.VaultObjectTypeKey,
 				ObjectAlias: "ecccert1-pub-key",
 			},
 			{
 				ObjectName:  "pemcert1",
-				ObjectType:  provider.VaultObjectTypeSecret,
+				ObjectType:  types.VaultObjectTypeSecret,
 				ObjectAlias: "pemcert1-secret",
 			},
 			{
 				ObjectName:  "pkcs12cert1",
-				ObjectType:  provider.VaultObjectTypeSecret,
+				ObjectType:  types.VaultObjectTypeSecret,
 				ObjectAlias: "pkcs12cert1-secret",
 			},
 			{
 				ObjectName:  "ecccert1",
-				ObjectType:  provider.VaultObjectTypeSecret,
+				ObjectType:  types.VaultObjectTypeSecret,
 				ObjectAlias: "ecccert1-secret",
 			},
 			{
 				ObjectName:   "pkcs12cert1",
-				ObjectType:   provider.VaultObjectTypeSecret,
+				ObjectType:   types.VaultObjectTypeSecret,
 				ObjectAlias:  "pkcs12cert1-secret-pfx",
 				ObjectFormat: "pfx",
 			},
 			{
 				ObjectName:   "ecccert1",
-				ObjectType:   provider.VaultObjectTypeSecret,
+				ObjectType:   types.VaultObjectTypeSecret,
 				ObjectAlias:  "ecccert1-secret-pfx",
 				ObjectFormat: "pfx",
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -121,9 +121,9 @@ var _ = Describe("When fetching certificates and private key from Key Vault", fu
 			Spec: v1alpha1.SecretProviderClassSpec{
 				Provider: "azure",
 				Parameters: map[string]string{
-					"keyvaultName": config.KeyvaultName,
-					"tenantId":     config.TenantID,
-					"objects":      string(objects),
+					types.KeyVaultNameParameter: config.KeyvaultName,
+					types.TenantIDParameter:     config.TenantID,
+					types.ObjectsParameter:      string(objects),
 				},
 			},
 		})

--- a/test/e2e/custom_cloudenv_test.go
+++ b/test/e2e/custom_cloudenv_test.go
@@ -6,7 +6,7 @@ package e2e
 import (
 	"strings"
 
-	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/exec"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/namespace"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/pod"
@@ -43,19 +43,19 @@ var _ = Describe("When deploying SecretProviderClass CRD with secrets for custom
 			Labels:    map[string]string{"secrets-store.csi.k8s.io/used": "true"},
 		})
 
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: "secret1",
-				ObjectType: provider.VaultObjectTypeSecret,
+				ObjectType: types.VaultObjectTypeSecret,
 			},
 			{
 				ObjectName:  "secret1",
-				ObjectType:  provider.VaultObjectTypeSecret,
+				ObjectType:  types.VaultObjectTypeSecret,
 				ObjectAlias: "SECRET_1",
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -73,11 +73,11 @@ var _ = Describe("When deploying SecretProviderClass CRD with secrets for custom
 			Spec: v1alpha1.SecretProviderClassSpec{
 				Provider: "azure",
 				Parameters: map[string]string{
-					"keyvaultName":     config.KeyvaultName,
-					"tenantId":         config.TenantID,
-					"cloudName":        "AzureStackCloud",
-					"cloudEnvFileName": config.AzureEnvironmentFilePath,
-					"objects":          string(objects),
+					types.KeyVaultNameParameter:     config.KeyvaultName,
+					types.TenantIDParameter:         config.TenantID,
+					types.CloudNameParameter:        "AzureStackCloud",
+					types.CloudEnvFileNameParameter: config.AzureEnvironmentFilePath,
+					types.ObjectsParameter:          string(objects),
 				},
 			},
 		})

--- a/test/e2e/key_test.go
+++ b/test/e2e/key_test.go
@@ -6,20 +6,18 @@ package e2e
 import (
 	"strings"
 
-	"github.com/ghodss/yaml"
-
-	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/exec"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/namespace"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/pod"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/secret"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/secretproviderclass"
 
+	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
-
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("When deploying SecretProviderClass CRD with keys", func() {
@@ -45,19 +43,19 @@ var _ = Describe("When deploying SecretProviderClass CRD with keys", func() {
 			Labels:    map[string]string{"secrets-store.csi.k8s.io/used": "true"},
 		})
 
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: "key1",
-				ObjectType: provider.VaultObjectTypeKey,
+				ObjectType: types.VaultObjectTypeKey,
 			},
 			{
 				ObjectName:  "key1",
-				ObjectType:  provider.VaultObjectTypeKey,
+				ObjectType:  types.VaultObjectTypeKey,
 				ObjectAlias: "KEY_1",
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -75,9 +73,9 @@ var _ = Describe("When deploying SecretProviderClass CRD with keys", func() {
 			Spec: v1alpha1.SecretProviderClassSpec{
 				Provider: "azure",
 				Parameters: map[string]string{
-					"keyvaultName": config.KeyvaultName,
-					"tenantId":     config.TenantID,
-					"objects":      string(objects),
+					types.KeyVaultNameParameter: config.KeyvaultName,
+					types.TenantIDParameter:     config.TenantID,
+					types.ObjectsParameter:      string(objects),
 				},
 			},
 		})
@@ -146,14 +144,14 @@ var _ = Describe("When deploying SecretProviderClass CRD with keys", func() {
 		}
 
 		// update the secretproviderclass to reference rsa-hsm keys
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: "rsahsmkey1",
-				ObjectType: provider.VaultObjectTypeKey,
+				ObjectType: types.VaultObjectTypeKey,
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -163,7 +161,7 @@ var _ = Describe("When deploying SecretProviderClass CRD with keys", func() {
 		objects, err := yaml.Marshal(yamlArray)
 		Expect(err).To(BeNil())
 
-		spc.Spec.Parameters["objects"] = string(objects)
+		spc.Spec.Parameters[types.ObjectsParameter] = string(objects)
 		spc = secretproviderclass.Update(secretproviderclass.UpdateInput{
 			Updater:             kubeClient,
 			SecretProviderClass: spc,
@@ -200,14 +198,14 @@ var _ = Describe("When deploying SecretProviderClass CRD with keys", func() {
 		}
 
 		// update the secretproviderclass to reference rsa-hsm keys
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: "echsmkey1",
-				ObjectType: provider.VaultObjectTypeKey,
+				ObjectType: types.VaultObjectTypeKey,
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -217,7 +215,7 @@ var _ = Describe("When deploying SecretProviderClass CRD with keys", func() {
 		objects, err := yaml.Marshal(yamlArray)
 		Expect(err).To(BeNil())
 
-		spc.Spec.Parameters["objects"] = string(objects)
+		spc.Spec.Parameters[types.ObjectsParameter] = string(objects)
 		spc = secretproviderclass.Update(secretproviderclass.UpdateInput{
 			Updater:             kubeClient,
 			SecretProviderClass: spc,

--- a/test/e2e/pod_identity_test.go
+++ b/test/e2e/pod_identity_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/exec"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/helm"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/namespace"
@@ -59,18 +59,18 @@ var _ = Describe("CSI inline volume test with aad-pod-identity", func() {
 			Name:    specName,
 		})
 
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: "secret1",
-				ObjectType: provider.VaultObjectTypeSecret,
+				ObjectType: types.VaultObjectTypeSecret,
 			},
 			{
 				ObjectName: "key1",
-				ObjectType: provider.VaultObjectTypeKey,
+				ObjectType: types.VaultObjectTypeKey,
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -88,11 +88,11 @@ var _ = Describe("CSI inline volume test with aad-pod-identity", func() {
 			Spec: v1alpha1.SecretProviderClassSpec{
 				Provider: "azure",
 				Parameters: map[string]string{
-					"keyvaultName":         config.KeyvaultName,
-					"tenantId":             config.TenantID,
-					"objects":              string(objects),
-					"usePodIdentity":       "true",
-					"useVMManagedIdentity": "false",
+					types.KeyVaultNameParameter:         config.KeyvaultName,
+					types.TenantIDParameter:             config.TenantID,
+					types.ObjectsParameter:              string(objects),
+					types.UsePodIdentityParameter:       "true",
+					types.UseVMManagedIdentityParameter: "false",
 				},
 			},
 		})

--- a/test/e2e/secret_file_permission_test.go
+++ b/test/e2e/secret_file_permission_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/exec"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/namespace"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/pod"
@@ -45,15 +45,15 @@ var _ = Describe("When user provides file permission for secrets", func() {
 			Labels:    map[string]string{"secrets-store.csi.k8s.io/used": "true"},
 		})
 
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName:     "secret1",
-				ObjectType:     provider.VaultObjectTypeSecret,
+				ObjectType:     types.VaultObjectTypeSecret,
 				FilePermission: fmt.Sprintf("0%s", expectedFilePermission),
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -71,9 +71,9 @@ var _ = Describe("When user provides file permission for secrets", func() {
 			Spec: v1alpha1.SecretProviderClassSpec{
 				Provider: "azure",
 				Parameters: map[string]string{
-					"keyvaultName": config.KeyvaultName,
-					"tenantId":     config.TenantID,
-					"objects":      string(objects),
+					types.KeyVaultNameParameter: config.KeyvaultName,
+					types.TenantIDParameter:     config.TenantID,
+					types.ObjectsParameter:      string(objects),
 				},
 			},
 		})

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -6,7 +6,7 @@ package e2e
 import (
 	"strings"
 
-	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/exec"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/namespace"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/pod"
@@ -45,23 +45,23 @@ var _ = Describe("When deploying SecretProviderClass CRD with secrets", func() {
 			Labels:    map[string]string{"secrets-store.csi.k8s.io/used": "true"},
 		})
 
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: "secret1",
-				ObjectType: provider.VaultObjectTypeSecret,
+				ObjectType: types.VaultObjectTypeSecret,
 			},
 			{
 				ObjectName:  "secret1",
-				ObjectType:  provider.VaultObjectTypeSecret,
+				ObjectType:  types.VaultObjectTypeSecret,
 				ObjectAlias: "SECRET_1",
 			},
 			{
 				ObjectName: "pemcert1",
-				ObjectType: provider.VaultObjectTypeSecret,
+				ObjectType: types.VaultObjectTypeSecret,
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -79,9 +79,9 @@ var _ = Describe("When deploying SecretProviderClass CRD with secrets", func() {
 			Spec: v1alpha1.SecretProviderClassSpec{
 				Provider: "azure",
 				Parameters: map[string]string{
-					"keyvaultName": config.KeyvaultName,
-					"tenantId":     config.TenantID,
-					"objects":      string(objects),
+					types.KeyVaultNameParameter: config.KeyvaultName,
+					types.TenantIDParameter:     config.TenantID,
+					types.ObjectsParameter:      string(objects),
 				},
 				SecretObjects: []*v1alpha1.SecretObject{
 					{

--- a/test/e2e/user_assigned_identity_test.go
+++ b/test/e2e/user_assigned_identity_test.go
@@ -6,7 +6,7 @@ package e2e
 import (
 	"strings"
 
-	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/exec"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/namespace"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/pod"
@@ -33,18 +33,18 @@ var _ = Describe("CSI inline volume test with user assigned identity", func() {
 			Name:    specName,
 		})
 
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: "secret1",
-				ObjectType: provider.VaultObjectTypeSecret,
+				ObjectType: types.VaultObjectTypeSecret,
 			},
 			{
 				ObjectName: "key1",
-				ObjectType: provider.VaultObjectTypeKey,
+				ObjectType: types.VaultObjectTypeKey,
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -62,11 +62,11 @@ var _ = Describe("CSI inline volume test with user assigned identity", func() {
 			Spec: v1alpha1.SecretProviderClassSpec{
 				Provider: "azure",
 				Parameters: map[string]string{
-					"keyvaultName":           config.KeyvaultName,
-					"tenantId":               config.TenantID,
-					"objects":                string(objects),
-					"useVMManagedIdentity":   "true",
-					"userAssignedIdentityID": config.UserAssignedIdentityID,
+					types.KeyVaultNameParameter:           config.KeyvaultName,
+					types.TenantIDParameter:               config.TenantID,
+					types.ObjectsParameter:                string(objects),
+					types.UseVMManagedIdentityParameter:   "true",
+					types.UserAssignedIdentityIDParameter: config.UserAssignedIdentityID,
 				},
 			},
 		})

--- a/test/e2e/workload_identity_test.go
+++ b/test/e2e/workload_identity_test.go
@@ -6,7 +6,7 @@ package e2e
 import (
 	"strings"
 
-	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/exec"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/namespace"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/pod"
@@ -38,18 +38,18 @@ var _ = Describe("CSI inline volume test with workload identity", func() {
 			Name:    specName,
 		})
 
-		keyVaultObjects := []provider.KeyVaultObject{
+		keyVaultObjects := []types.KeyVaultObject{
 			{
 				ObjectName: "secret1",
-				ObjectType: provider.VaultObjectTypeSecret,
+				ObjectType: types.VaultObjectTypeSecret,
 			},
 			{
 				ObjectName: "key1",
-				ObjectType: provider.VaultObjectTypeKey,
+				ObjectType: types.VaultObjectTypeKey,
 			},
 		}
 
-		yamlArray := provider.StringArray{Array: []string{}}
+		yamlArray := types.StringArray{Array: []string{}}
 		for _, object := range keyVaultObjects {
 			obj, err := yaml.Marshal(object)
 			Expect(err).To(BeNil())
@@ -67,12 +67,12 @@ var _ = Describe("CSI inline volume test with workload identity", func() {
 			Spec: v1alpha1.SecretProviderClassSpec{
 				Provider: "azure",
 				Parameters: map[string]string{
-					"keyvaultName":         config.KeyvaultName,
-					"tenantId":             config.TenantID,
-					"objects":              string(objects),
-					"usePodIdentity":       "false",
-					"useVMManagedIdentity": "false",
-					"clientID":             config.AzureClientID,
+					types.KeyVaultNameParameter:         config.KeyvaultName,
+					types.TenantIDParameter:             config.TenantID,
+					types.ObjectsParameter:              string(objects),
+					types.UsePodIdentityParameter:       "false",
+					types.UseVMManagedIdentityParameter: "false",
+					types.ClientIDParameter:             config.AzureClientID,
 				},
 			},
 		})


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds functions to get parameters from the attributes map
- Adds unit tests to validate the get parameters functions
- Makes the parameter names constant, so it can be reused in code and tests

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
