### PR TITLE
fix: use `tenantID` instead of `tenantId` in parameters

### DIFF
--- a/pkg/provider/types/parameters.go
+++ b/pkg/provider/types/parameters.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v2"
+	"k8s.io/klog/v2"
 )
 
 // GetKeyVaultName returns the key vault name
@@ -42,6 +43,12 @@ func GetUserAssignedIdentityID(parameters map[string]string) string {
 
 // GetTenantID returns the tenant ID
 func GetTenantID(parameters map[string]string) string {
+	// ref: https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/857
+	tenantID := strings.TrimSpace(parameters["tenantID"])
+	if tenantID != "" {
+		return tenantID
+	}
+	klog.V(3).Info("tenantId is deprecated and will be removed in a future release. Use 'tenantID' instead")
 	return strings.TrimSpace(parameters[TenantIDParameter])
 }
 

--- a/pkg/provider/types/parameters_test.go
+++ b/pkg/provider/types/parameters_test.go
@@ -293,6 +293,20 @@ func TestGetTenantID(t *testing.T) {
 			},
 			expected: "test",
 		},
+		{
+			name: "new tenantID parameter",
+			parameters: map[string]string{
+				"tenantID": "test",
+			},
+			expected: "test",
+		},
+		{
+			name: "new tenantID parameter with spaces",
+			parameters: map[string]string{
+				"tenantID": " test ",
+			},
+			expected: "test",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/provider/types/types.go
+++ b/pkg/provider/types/types.go
@@ -38,6 +38,8 @@ const (
 	// UserAssignedIdentityIDParameter is the name of the user assigned identity ID parameter
 	UserAssignedIdentityIDParameter = "userAssignedIdentityID"
 	// TenantIDParameter is the name of the tenant ID parameter
+	// TODO(aramase): change this from tenantId to tenantID after v1.2 release
+	// ref: https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/857
 	TenantIDParameter = "tenantId"
 	// CloudEnvFileNameParameter is the name of the cloud env file name parameter
 	CloudEnvFileNameParameter = "cloudEnvFileName"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Changes the tenant id parameter to `tenantID` from `tenantId` to be consistent with the naming convention.
- This change is backward compatible as we fallback on `tenantId` in case `tenantID` is not set.
  - The `TenantIDParameter` constant can be changed to `tenantID` after 1.2 release as it's used in upgrade tests.
  - We'll need to keep the old `tenantId` parameter a couple of releases before we completely remove it.
  - The log is set at level 3 instead of warning, as warning can be too verbose and logged every time the we get a mount request.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #857 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
