### PR TITLE
test: skip pod identity tests for arc

### DIFF
--- a/test/e2e/auto_rotation_test.go
+++ b/test/e2e/auto_rotation_test.go
@@ -307,6 +307,9 @@ var _ = Describe("Test auto rotation of mount contents and K8s secrets", func() 
 		if config.IsWindowsTest {
 			Skip("test case not supported for windows cluster")
 		}
+		if config.IsArcTest {
+			Skip("test is not supported in Arc cluster")
+		}
 
 		secretName := fmt.Sprintf("secret-pi-%s", utilrand.String(randomLength))
 		// create secret in keyvault

--- a/test/e2e/pod_identity_test.go
+++ b/test/e2e/pod_identity_test.go
@@ -123,6 +123,9 @@ var _ = Describe("CSI inline volume test with aad-pod-identity", func() {
 		if config.IsWindowsTest {
 			Skip("test case not supported for windows cluster")
 		}
+		if config.IsArcTest {
+			Skip("test is not supported in Arc cluster")
+		}
 
 		By("Deploying aad-pod-identity")
 		helm.InstallPodIdentity()


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
Fixes failures in arc nightly test runs: https://dev.azure.com/AzureContainerUpstream/Secrets%20Store%20CSI%20Driver%20Provider%20Azure/_build/results?buildId=45173&view=logs&jobId=51811eea-cde0-5499-71d2-3da72322665f
- Skips pod identity tests for arc testing

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
