### PR TITLE
chore: update debian-base to bullseye-v1.3.0

### DIFF
--- a/arc/conformance/plugin/Dockerfile
+++ b/arc/conformance/plugin/Dockerfile
@@ -2,7 +2,7 @@ ARG STEP_CLI_VERSION=0.18.0
 ARG STEP_CLI_IMAGE=smallstep/step-cli:${STEP_CLI_VERSION}
 FROM $STEP_CLI_IMAGE as step-cli
 
-FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.2.0
+FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.3.0
 ARG KUBE_VERSION=v1.21.2
 ARG TARGETARCH
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Update debian-base to bullseye-v1.3.0

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
