### PR TITLE
chore: add additional logs in fetch cert chain

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -504,7 +504,7 @@ func getCurve(crv kv.JSONWebKeyCurveName) (elliptic.Curve, error) {
 	case kv.P521:
 		return elliptic.P521(), nil
 	default:
-		return nil, fmt.Errorf("curve %s is not suppported", crv)
+		return nil, fmt.Errorf("curve %s is not supported", crv)
 	}
 }
 
@@ -655,6 +655,7 @@ type node struct {
 	isParent bool
 }
 
+// implementation xref: https://social.technet.microsoft.com/wiki/contents/articles/3147.pki-certificate-chaining-engine-cce.aspx#Building_the_Certificate_Chain
 func fetchCertChains(data []byte) ([]byte, error) {
 	var newCertChain []*x509.Certificate
 	var pemData []byte
@@ -728,6 +729,10 @@ func fetchCertChains(data []byte) ([]byte, error) {
 		}
 		newCertChain = append(newCertChain, leaf.cert)
 		leaf = leaf.parent
+	}
+
+	if len(nodes) != len(newCertChain) {
+		klog.Warning("certificate chain is not complete due to missing intermediate/root certificates in the cert from key vault")
 	}
 
 	for _, cert := range newCertChain {


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Adds a warning log when the number of certs after reconstructing certificate chain is not equal to the number of certs from key vault.
  - This can be caused when the chain is incomplete

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #879 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
