### PR TITLE
test: fix junit reporter filename

### DIFF
--- a/arc/conformance/plugin/arc_conformance.sh
+++ b/arc/conformance/plugin/arc_conformance.sh
@@ -45,7 +45,7 @@ trap saveResult EXIT
 
 # initial environment variables for the plugin
 setEnviornmentVariables() {
-  export JUNIT_OUTPUT_FILEPATH=/tmp/results/junit.xml
+  export JUNIT_OUTPUT_FILEPATH=/tmp/results/
   export IS_ARC_TEST=true
   export CI_KIND_CLUSTER=true
   export ACK_GINKGO_DEPRECATIONS=1.16.4 # remove this when we move to ginkgo 2.0

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -50,7 +51,7 @@ const (
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	// adding JUnitReporter for arc conformance test. If JUNIT_OUTPUT_FILEPATH is empty, it will not produce xml output.
-	junitReporter := reporters.NewJUnitReporter(os.Getenv("JUNIT_OUTPUT_FILEPATH"))
+	junitReporter := reporters.NewJUnitReporter(filepath.Join(os.Getenv("JUNIT_OUTPUT_FILEPATH"), "junit.xml"))
 	RunSpecsWithDefaultAndCustomReporters(t, "sscdproviderazure", []Reporter{junitReporter})
 }
 


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
```bash
Failed to create JUnit report file: /mnt/vss/_work/1/s/test/e2e
	open /mnt/vss/_work/1/s/test/e2e: is a directory
Failed to generate JUnit report data:
	invalid argument
```
- Adds a filename for the junit report to be used by the reporter. 
  - It fails now because `JUNIT_OUTPUT_FILEPATH` is a directory

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
