### PR TITLE
ci: remove kubernetes version 1.21 (EOL)

### DIFF
--- a/.pipelines/templates/e2e-test-kind.yaml
+++ b/.pipelines/templates/e2e-test-kind.yaml
@@ -13,29 +13,23 @@ jobs:
     - group: csi-secrets-store-e2e-kind
     strategy:
       matrix:
-        kind_v1_21_10_helm:
-          KIND_K8S_VERSION: v1.21.10
+        kind_v1_22_9_helm:
+          KIND_K8S_VERSION: v1.22.9
           IS_HELM_TEST: true
-        kind_v1_22_7_helm:
-          KIND_K8S_VERSION: v1.22.7
+        kind_v1_23_6_helm:
+          KIND_K8S_VERSION: v1.23.6
           IS_HELM_TEST: true
-        kind_v1_23_5_helm:
-          KIND_K8S_VERSION: v1.23.5
+        kind_v1_24_2_helm:
+          KIND_K8S_VERSION: v1.24.2
           IS_HELM_TEST: true
-        kind_v1_24_0_helm:
-          KIND_K8S_VERSION: v1.24.0
-          IS_HELM_TEST: true
-        kind_v1_21_10_deployment_manifest:
-          KIND_K8S_VERSION: v1.21.10
-          IS_HELM_TEST: false
-        kind_v1_22_7_deployment_manifest:
-          KIND_K8S_VERSION: v1.22.7
+        kind_v1_22_9_deployment_manifest:
+          KIND_K8S_VERSION: v1.22.9
           IS_HELM_TEST: false 
-        kind_v1_23_5_deployment_manifest:
-          KIND_K8S_VERSION: v1.23.5
+        kind_v1_23_6_deployment_manifest:
+          KIND_K8S_VERSION: v1.23.6
           IS_HELM_TEST: false
-        kind_v1_24_0_deployment_manifest:
-          KIND_K8S_VERSION: v1.24.0
+        kind_v1_24_2_deployment_manifest:
+          KIND_K8S_VERSION: v1.24.2
           IS_HELM_TEST: false
 
     steps:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- Remove Kubernetes version 1.21 from CI since it has reached EOL
- Update Kubernetes versions to latest in CI for supported releases

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
