### PR TITLE
docs: add release cadence to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Try our [walkthrough](https://azure.github.io/secrets-store-csi-driver-provider-
 
 Please refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for more information.
 
+## Release
+
+Currently, this project releases monthly to patch security vulnerabilities, and bi-monthly for new features. We target the **second week** of the month for release.
+
 ## Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Currently - we do have the release cadence documented in the docs folder, but I'd like to surface it in the README to make it as visible as possible
