### PR TITLE
fix bug #948 arc missing system identity

### DIFF
--- a/arc/portal_gallery_package/DeploymentTemplates/DefaultTemplate.json
+++ b/arc/portal_gallery_package/DeploymentTemplates/DefaultTemplate.json
@@ -41,6 +41,10 @@
             "type": "Microsoft.KubernetesConfiguration/extensions",
             "apiVersion": "2021-09-01",
             "name": "[parameters('extensionName')]",
+            "scope": "[concat('Microsoft.Kubernetes/connectedClusters/', parameters('connectedClusterName'))]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
             "tags": "[ if(contains(parameters('tagsByResource'), 'Microsoft.KubernetesConfiguration/extensions'), parameters('tagsByResource')['Microsoft.KubernetesConfiguration/extensions'], json('{}')) ]",
             "properties": {
                 "extensionType": "Microsoft.AzureKeyVaultSecretsProvider",
@@ -55,8 +59,7 @@
                     "secrets-store-csi-driver.rotationPollInterval": "[parameters('rotationPollInterval')]",
                     "secrets-store-csi-driver.syncSecret.enabled": "[parameters('enableSyncSecret')]"
                 }
-            },
-            "scope": "[concat('Microsoft.Kubernetes/connectedClusters/', parameters('connectedClusterName'))]"
+            }
         }
     ]
 }


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
The Azure Portal Gallery deployment for Arc is missing the SystemAssigned identity causing missing rolebindings on the cluster. 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #948

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:

Co-author: @eliises