### PR TITLE
URL fix - pointing to wrong branch

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -21,7 +21,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-1.0.1.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-1.0.1.tgz
     version: 1.0.1
   - apiVersion: v2
     appVersion: 1.0.0
@@ -43,7 +43,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-1.0.0.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-1.0.0.tgz
     version: 1.0.0
   - apiVersion: v2
     appVersion: 1.0.0-rc.0
@@ -65,7 +65,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-1.0.0-rc.0.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-1.0.0-rc.0.tgz
     version: 1.0.0-rc.0
   - apiVersion: v2
     appVersion: 0.2.0
@@ -87,7 +87,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.2.1.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v2
     appVersion: 0.2.0
@@ -109,7 +109,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.2.0.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v2
     appVersion: 0.1.0
@@ -131,7 +131,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.1.0.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.1.0.tgz
     version: 0.1.0
   - apiVersion: v1
     appVersion: 0.0.16
@@ -153,7 +153,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.20.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.20.tgz
     version: 0.0.20
   - apiVersion: v1
     appVersion: 0.0.15
@@ -175,7 +175,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.19.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.19.tgz
     version: 0.0.19
   - apiVersion: v1
     appVersion: 0.0.14
@@ -197,7 +197,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.18.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.18.tgz
     version: 0.0.18
   - apiVersion: v1
     appVersion: 0.0.13
@@ -219,7 +219,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.17.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.17.tgz
     version: 0.0.17
   - apiVersion: v1
     appVersion: 0.0.12
@@ -241,7 +241,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.16.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.16.tgz
     version: 0.0.16
   - apiVersion: v1
     appVersion: 0.0.11
@@ -263,7 +263,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.15.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.15.tgz
     version: 0.0.15
   - apiVersion: v1
     appVersion: 0.0.10
@@ -285,7 +285,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.14.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.14.tgz
     version: 0.0.14
   - apiVersion: v1
     appVersion: 0.0.9
@@ -307,7 +307,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.13.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.13.tgz
     version: 0.0.13
   - apiVersion: v1
     appVersion: 0.0.9
@@ -329,7 +329,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.12.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.12.tgz
     version: 0.0.12
   - apiVersion: v1
     appVersion: 0.0.9
@@ -351,7 +351,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.11.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.11.tgz
     version: 0.0.11
   - apiVersion: v1
     appVersion: 0.0.8
@@ -373,7 +373,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.10.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.10.tgz
     version: 0.0.10
   - apiVersion: v1
     appVersion: 0.0.7
@@ -395,7 +395,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.9.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.9.tgz
     version: 0.0.9
   - apiVersion: v1
     appVersion: 0.0.7
@@ -417,7 +417,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.8.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.8.tgz
     version: 0.0.8
   - apiVersion: v1
     appVersion: 0.0.6
@@ -439,7 +439,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.7.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.7.tgz
     version: 0.0.7
   - apiVersion: v1
     appVersion: 0.0.5
@@ -461,7 +461,7 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.6.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.6.tgz
     version: 0.0.6
   - apiVersion: v1
     appVersion: 0.0.5
@@ -483,6 +483,6 @@ entries:
     sources:
     - https://github.com/Azure/secrets-store-csi-driver-provider-azure
     urls:
-    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/csi-secrets-store-provider-azure-0.0.5.tgz
+    - https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/release-1.3/charts/csi-secrets-store-provider-azure-0.0.5.tgz
     version: 0.0.5
 generated: "2022-01-14T20:15:30.825253171Z"


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
Removal of index in master branch (PR: https://github.com/Azure/secrets-store-csi-driver-provider-azure/pull/924) forced me to use release branches to get the charts (which is fine), but there is mistake in every release branch index.yaml file - URL is pointing to master, where older versions were removed in the same PR. Fixing latest release.
<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
