### PR TITLE
chore: bump k8s versions for kind tests

### DIFF
--- a/.pipelines/templates/e2e-test-kind.yaml
+++ b/.pipelines/templates/e2e-test-kind.yaml
@@ -13,29 +13,29 @@ jobs:
     - group: csi-secrets-store-e2e-kind
     strategy:
       matrix:
-        kind_v1_22_9_helm:
-          KIND_K8S_VERSION: v1.22.9
+        kind_v1_22_15_helm:
+          KIND_K8S_VERSION: v1.22.15
           IS_HELM_TEST: true
-        kind_v1_23_6_helm:
-          KIND_K8S_VERSION: v1.23.6
+        kind_v1_23_12_helm:
+          KIND_K8S_VERSION: v1.23.12
           IS_HELM_TEST: true
-        kind_v1_24_2_helm:
-          KIND_K8S_VERSION: v1.24.2
+        kind_v1_24_6_helm:
+          KIND_K8S_VERSION: v1.24.6
           IS_HELM_TEST: true
-        kind_v1_25_0_helm:
+        kind_v1_25_2_helm:
           KIND_K8S_VERSION: v1.25.0
           IS_HELM_TEST: true
-        kind_v1_22_9_deployment_manifest:
-          KIND_K8S_VERSION: v1.22.9
+        kind_v1_22_15_deployment_manifest:
+          KIND_K8S_VERSION: v1.22.15
           IS_HELM_TEST: false 
-        kind_v1_23_6_deployment_manifest:
-          KIND_K8S_VERSION: v1.23.6
+        kind_v1_23_12_deployment_manifest:
+          KIND_K8S_VERSION: v1.23.12
           IS_HELM_TEST: false
-        kind_v1_24_2_deployment_manifest:
-          KIND_K8S_VERSION: v1.24.2
+        kind_v1_24_6_deployment_manifest:
+          KIND_K8S_VERSION: v1.24.6
           IS_HELM_TEST: false
-        kind_v1_25_0_deployment_manifest:
-          KIND_K8S_VERSION: v1.25.0
+        kind_v1_25_2_deployment_manifest:
+          KIND_K8S_VERSION: v1.25.2
           IS_HELM_TEST: false
 
     steps:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- The e2e pipeline has been flaky and fails during `kind create cluster`. This could be a bug with the older kubernetes version, so bumping to latest available images.

xref: https://github.com/kubernetes-sigs/kind/issues/2942

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
