### PR TITLE
docs: fix workload identity link

### DIFF
--- a/website/content/en/getting-started/usage/_index.md
+++ b/website/content/en/getting-started/usage/_index.md
@@ -92,7 +92,7 @@ The Azure Key Vault Provider offers five modes for accessing a Key Vault instanc
 2. [Pod Identity](../../configurations/identity-access-modes/pod-identity-mode)
 3. [User-assigned Managed Identity](../../configurations/identity-access-modes/user-assigned-msi-mode)
 4. [System-assigned Managed Identity](../../configurations/identity-access-modes/system-assigned-msi-mode)
-5. [Workload Identity](../../configurations/identity-access-modes/workload-identity-mode.md)
+5. [Workload Identity](../../configurations/identity-access-modes/workload-identity-mode)
 
 #### Update your Deployment Yaml
 


### PR DESCRIPTION
Signed-off-by: Javier Vela <fjvela@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**: Fix a 404 error link to Workload Identity config page
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
