### PR TITLE
ci: enable tests with kubernetes v1.26

### DIFF
--- a/.pipelines/templates/e2e-test-kind.yaml
+++ b/.pipelines/templates/e2e-test-kind.yaml
@@ -22,6 +22,9 @@ jobs:
         kind_v1_25_3_helm:
           KIND_K8S_VERSION: v1.25.3
           IS_HELM_TEST: true
+        kind_v1_26_0_helm:
+          KIND_K8S_VERSION: v1.26.0
+          IS_HELM_TEST: true
         kind_v1_23_13_deployment_manifest:
           KIND_K8S_VERSION: v1.23.13
           IS_HELM_TEST: false
@@ -30,6 +33,9 @@ jobs:
           IS_HELM_TEST: false
         kind_v1_25_3_deployment_manifest:
           KIND_K8S_VERSION: v1.25.3
+          IS_HELM_TEST: false
+        kind_v1_26_0_deployment_manifest:
+          KIND_K8S_VERSION: v1.26.0
           IS_HELM_TEST: false
 
     steps:


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- enable tests with kubernetes v1.26

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
