### PR TITLE
test: update helm install logic for upgrade tests

### DIFF
--- a/.pipelines/templates/e2e-test.yaml
+++ b/.pipelines/templates/e2e-test.yaml
@@ -3,7 +3,7 @@ parameters:
     type: string
   - name: testReleasedVersion
     type: boolean
-    default: false    
+    default: false
   - name: resetImageVersion
     type: boolean
     default: false
@@ -47,9 +47,7 @@ steps:
         export REGISTRY="${REGISTRY:-$(REGISTRY_NAME).azurecr.io/k8s/csi/secrets-store}"
       fi
       if [ "${{ parameters.testReleasedVersion }}" == True ] ; then
-        export HELM_CHART_DIR=charts/csi-secrets-store-provider-azure
-      else
-        export HELM_CHART_DIR=manifest_staging/charts/csi-secrets-store-provider-azure
+        export HELM_CHART_DIR=https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
       fi
       make e2e-test
     displayName: "${{ parameters.testName }}"
@@ -72,7 +70,7 @@ steps:
         CI_KIND_CLUSTER: ${{ parameters.ciKindCluster }}
       ${{ if parameters.isArcTest }}:
         IS_ARC_TEST: ${{ parameters.isArcTest }}
-      # If the image is a released versions (i.e <= v1.3), it still doesn't support the 
+      # If the image is a released versions (i.e <= v1.3), it still doesn't support the
       # split cert/key feature, so we need to skip tests for those versions.
       ${{ if parameters.testReleasedVersion }}:
         GINKGO_SKIP: WriteCertAndKeyInSeparateFiles

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -103,7 +103,6 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	// cleanup
 	defer func() {
 		// uninstall if it's not Soak Test, not backward compatibility test and if cluster is already upgraded or it's not cluster upgrade test
 		if !config.IsSoakTest && !config.IsArcTest && !config.IsBackwardCompatibilityTest && (!config.IsUpgradeTest || config.IsClusterUpgraded) {

--- a/test/e2e/framework/helm/helm.go
+++ b/test/e2e/framework/helm/helm.go
@@ -20,6 +20,7 @@ const (
 	// see https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/596
 	chartName            = "csi-secrets-store-provider-azure"
 	podIdentityChartName = "pi"
+	providerChartsRepo   = "https://azure.github.io/secrets-store-csi-driver-provider-azure/charts"
 )
 
 // InstallInput is the input for Install.
@@ -41,6 +42,17 @@ func Install(input InstallInput) {
 	defer os.Chdir(cwd)
 
 	chartDir := input.Config.HelmChartDir
+	// if chartDir is the official helm repo, then add the repo and update so the latest package is used
+	if chartDir == providerChartsRepo {
+		args := append([]string{"repo", "add", "csi-secrets-store-provider-azure", providerChartsRepo})
+		err := helm(args)
+		Expect(err).To(BeNil())
+
+		args = append([]string{"repo", "update"})
+		err = helm(args)
+		Expect(err).To(BeNil())
+		chartDir = "csi-secrets-store-provider-azure/csi-secrets-store-provider-azure"
+	}
 
 	args := append([]string{
 		"install",


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- update helm install logic for upgrade tests
  - we can't use `charts/csi-secrets-store-provider-azure` when cutting releases because the image will be latest and not yet available. So switching the logic to use the official helm chart repo to install the latest available provider.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
