### PR TITLE
ci: pin k8s-extension version to `1.3.5`

### DIFF
--- a/.pipelines/templates/arc/setup.yaml
+++ b/.pipelines/templates/arc/setup.yaml
@@ -4,7 +4,7 @@ parameters:
 steps:
   - script: |
       az extension add --name connectedk8s
-      az extension add --name k8s-extension
+      az extension add --name k8s-extension --version 1.3.5
       echo "az version:"
       az version
     displayName: "add cli extensions"


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- The PR gate and nightly test runs for arc are failing due to issues with the latest `k8s-extension`. Pinning to a specific version of the extension that works!

Test run with pinning the version: https://dev.azure.com/AzureContainerUpstream/Secrets%20Store%20CSI%20Driver%20Provider%20Azure/_build/results?buildId=77487&view=results

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
fixes #1076 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
