### PR TITLE
test: use `registry.k8s.io/e2e-test-images/busybox:1.29-4` for e2e

### DIFF
--- a/docs/sample/ingress-controller-tls/deployment-app-one.yaml
+++ b/docs/sample/ingress-controller-tls/deployment-app-one.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: busybox
-        image: k8s.gcr.io/e2e-test-images/busybox:1.29
+        image: registry.k8s.io/e2e-test-images/busybox:1.29-4
         command:
           - "/bin/sleep"
           - "10000"

--- a/docs/sample/ingress-controller-tls/deployment-app-two.yaml
+++ b/docs/sample/ingress-controller-tls/deployment-app-two.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: busybox
-        image: k8s.gcr.io/e2e-test-images/busybox:1.29
+        image: registry.k8s.io/e2e-test-images/busybox:1.29-4
         command:
           - "/bin/sleep"
           - "10000"

--- a/examples/pod-identity/pod-inline-volume-pod-identity.yaml
+++ b/examples/pod-identity/pod-inline-volume-pod-identity.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
       command:
         - "/bin/sleep"
         - "10000"

--- a/examples/service-principal/pod-inline-volume-service-principal.yaml
+++ b/examples/service-principal/pod-inline-volume-service-principal.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     command:
       - "/bin/sleep"
       - "10000"

--- a/examples/sync-as-kubernetes-secret/deployment-synck8s.yaml
+++ b/examples/sync-as-kubernetes-secret/deployment-synck8s.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
         - name: busybox
-          image: k8s.gcr.io/e2e-test-images/busybox:1.29
+          image: registry.k8s.io/e2e-test-images/busybox:1.29-4
           command:
             - "/bin/sleep"
             - "10000"

--- a/examples/system-assigned-managed-identity/pod-inline-volume-system-assigned-identity.yaml
+++ b/examples/system-assigned-managed-identity/pod-inline-volume-system-assigned-identity.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
       command:
         - "/bin/sleep"
         - "10000"

--- a/examples/user-assigned-managed-identity/pod-inline-volume-user-assigned-identity.yaml
+++ b/examples/user-assigned-managed-identity/pod-inline-volume-user-assigned-identity.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
     - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
       command:
         - "/bin/sleep"
         - "10000"

--- a/test/e2e/framework/pod/pod.go
+++ b/test/e2e/framework/pod/pod.go
@@ -72,7 +72,7 @@ func Create(input CreateInput) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:            "tester",
-					Image:           "k8s.gcr.io/e2e-test-images/busybox:1.29",
+					Image:           "registry.k8s.io/e2e-test-images/busybox:1.29-4",
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/bin/sleep", "10000"},
 					VolumeMounts: []corev1.VolumeMount{

--- a/website/content/en/configurations/identity-access-modes/pod-identity-mode.md
+++ b/website/content/en/configurations/identity-access-modes/pod-identity-mode.md
@@ -33,8 +33,8 @@ spec:
           objectName: key1
           objectType: key
           objectVersion: ""
-    tenantID: "tid"                    # the tenant ID of the KeyVault  
-``` 
+    tenantID: "tid"                    # the tenant ID of the KeyVault
+```
 
 - `Pod` yaml
 ```yaml
@@ -48,7 +48,7 @@ metadata:
 spec:
   containers:
     - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
       command:
         - "/bin/sleep"
         - "10000"
@@ -158,14 +158,14 @@ Not all steps need to be followed on the instructions for the aad-pod-identity p
     labels:
       aadpodidbinding: <AzureIdentityBinding Selector created from previous step>
     ```
-    
+
 7. Update [this sample deployment](https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/examples/pod-identity/v1alpha1_secretproviderclass_pod_identity.yaml) to create a `SecretProviderClass` resource with `usePodIdentity: "true"` to provide Azure-specific parameters for the Secrets Store CSI driver.
 
     Make sure to set `usePodIdentity` to `true`
     ```yaml
     usePodIdentity: "true"
     ```
-    
+
 8. Deploy your app
 
     ```bash

--- a/website/content/en/configurations/identity-access-modes/service-principal-mode.md
+++ b/website/content/en/configurations/identity-access-modes/service-principal-mode.md
@@ -4,7 +4,7 @@ title: "Service Principal"
 linkTitle: "Service Principal"
 weight: 3
 description: >
-  Use a Service Principal to access Keyvault. 
+  Use a Service Principal to access Keyvault.
 ---
 
 <details>
@@ -22,7 +22,7 @@ spec:
   parameters:
     usePodIdentity: "false"         # [OPTIONAL] if not provided, will default to "false"
     keyvaultName: "kvname"          # the name of the KeyVault
-    cloudName: ""                   # [OPTIONAL for Azure] if not provided, azure environment will default to AzurePublicCloud 
+    cloudName: ""                   # [OPTIONAL for Azure] if not provided, azure environment will default to AzurePublicCloud
     objects:  |
       array:
         - |
@@ -34,7 +34,7 @@ spec:
           objectType: key
           objectVersion: ""
     tenantID: "tid"                 # the tenant ID of the KeyVault
-``` 
+```
 
 - `Pod` yaml
 ```yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     command:
       - "/bin/sleep"
       - "10000"

--- a/website/content/en/configurations/identity-access-modes/system-assigned-msi-mode.md
+++ b/website/content/en/configurations/identity-access-modes/system-assigned-msi-mode.md
@@ -36,7 +36,7 @@ spec:
           objectType: key
           objectVersion: ""
     tenantID: "tid"                 # the tenant ID of the KeyVault
-``` 
+```
 
 - `Pod` yaml
 ```yaml
@@ -49,7 +49,7 @@ metadata:
 spec:
   containers:
     - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
       command:
         - "/bin/sleep"
         - "10000"

--- a/website/content/en/configurations/identity-access-modes/user-assigned-msi-mode.md
+++ b/website/content/en/configurations/identity-access-modes/user-assigned-msi-mode.md
@@ -35,8 +35,8 @@ spec:
           objectName: key1
           objectType: key
           objectVersion: ""
-    tenantID: "tid"                 # the tenant ID of the KeyVault  
-``` 
+    tenantID: "tid"                 # the tenant ID of the KeyVault
+```
 
 - `Pod` yaml
 ```yaml
@@ -48,7 +48,7 @@ metadata:
 spec:
   containers:
     - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
       command:
         - "/bin/sleep"
         - "10000"

--- a/website/content/en/configurations/identity-access-modes/workload-identity-mode.md
+++ b/website/content/en/configurations/identity-access-modes/workload-identity-mode.md
@@ -34,7 +34,7 @@ spec:
           objectName: key1
           objectType: key
           objectVersion: ""
-    tenantID: "tid"                    # the tenant ID of the KeyVault  
+    tenantID: "tid"                    # the tenant ID of the KeyVault
 ```
 
 - `Pod` yaml
@@ -47,7 +47,7 @@ metadata:
 spec:
   containers:
     - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
       command:
         - "/bin/sleep"
         - "10000"

--- a/website/content/en/configurations/set-env-var.md
+++ b/website/content/en/configurations/set-env-var.md
@@ -22,13 +22,13 @@ spec:
   secretObjects:                                 # [OPTIONAL] SecretObject defines the desired state of synced K8s secret objects
   - secretName: foosecret
     type: Opaque
-    labels:                                   
+    labels:
       environment: "test"
-    data: 
-    - objectName: secretalias                    # name of the mounted content to sync. this could be the object name or object alias 
+    data:
+    - objectName: secretalias                    # name of the mounted content to sync. this could be the object name or object alias
       key: username
   parameters:
-    usePodIdentity: "false"                      
+    usePodIdentity: "false"
     keyvaultName: "$KEYVAULT_NAME"               # the name of the KeyVault
     objects: |
       array:
@@ -54,7 +54,7 @@ metadata:
 spec:
   containers:
     - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
       command:
         - "/bin/sleep"
         - "10000"
@@ -87,7 +87,7 @@ Once the secret is created, you may wish to set an ENV VAR in your deployment to
 spec:
   containers:
   - name: busybox
-    image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     command:
       - "/bin/sleep"
       - "10000"

--- a/website/content/en/configurations/sync-multiple-versions.md
+++ b/website/content/en/configurations/sync-multiple-versions.md
@@ -20,7 +20,7 @@ metadata:
 spec:
   provider: azure
   parameters:
-    usePodIdentity: "true"                      
+    usePodIdentity: "true"
     keyvaultName: "$KEYVAULT_NAME"               # the name of the KeyVault
     objects: |
       array:
@@ -48,7 +48,7 @@ metadata:
 spec:
   containers:
     - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
       command:
         - "/bin/sleep"
         - "10000"
@@ -76,6 +76,6 @@ When you do this, the provider will treat the object name/alias as a folder and 
 {{% alert title="NOTE" color="warning" %}}
 
 - There may be fewer than `objectVersionHistory` versions synced. For instance if you specify 5 and the secret only has 3 versions, then only 3 versions will be synced.
-- Disabled versions of the secret are ignored. 
+- Disabled versions of the secret are ignored.
 
 {{% /alert %}}

--- a/website/content/en/configurations/sync-with-k8s-secrets.md
+++ b/website/content/en/configurations/sync-with-k8s-secrets.md
@@ -22,13 +22,13 @@ spec:
   secretObjects:                                 # [OPTIONAL] SecretObject defines the desired state of synced K8s secret objects
   - secretName: foosecret
     type: Opaque
-    labels:                                   
+    labels:
       environment: "test"
-    data: 
-    - objectName: secretalias                    # name of the mounted content to sync. this could be the object name or object alias 
+    data:
+    - objectName: secretalias                    # name of the mounted content to sync. this could be the object name or object alias
       key: username
   parameters:
-    usePodIdentity: "true"                      
+    usePodIdentity: "true"
     keyvaultName: "$KEYVAULT_NAME"               # the name of the KeyVault
     objects: |
       array:
@@ -54,7 +54,7 @@ metadata:
 spec:
   containers:
     - name: busybox
-      image: k8s.gcr.io/e2e-test-images/busybox:1.29
+      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
       command:
         - "/bin/sleep"
         - "10000"
@@ -96,7 +96,7 @@ kind: SecretProviderClass
 metadata:
   name: my-provider
 spec:
-  provider: azure                             
+  provider: azure
   secretObjects:                              # [OPTIONAL] SecretObject defines the desired state of synced K8s secret objects
   - data:
     - key: username                           # data field to populate

--- a/website/content/en/demos/standard-walkthrough/_index.md
+++ b/website/content/en/demos/standard-walkthrough/_index.md
@@ -100,7 +100,7 @@ spec:
     objects: |
       array:
         - |
-          objectName: secret1              
+          objectName: secret1
           objectType: secret
           objectVersion: ""
     tenantID: "${TENANT_ID}"
@@ -120,7 +120,7 @@ metadata:
 spec:
   containers:
   - name: busybox
-    image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     command:
       - "/bin/sleep"
       - "10000"
@@ -155,7 +155,7 @@ If successful, the output will be similar to:
   ```bash
   kubectl exec busybox-secrets-store-inline -- ls /mnt/secrets-store/
   secret1
-  
+
   kubectl exec busybox-secrets-store-inline -- cat /mnt/secrets-store/secret1
   Hello!
   ```


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
- use `registry.k8s.io/e2e-test-images/busybox:1.29-4` for e2e
  - `k8s.gcr.io/e2e-test-images/busybox:1.29` doesn't work with Windows 2022

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
