### PR TITLE
feat: adds outbound proxy env variable support for windows pod

### DIFF
--- a/manifest_staging/charts/csi-secrets-store-provider-azure/arc-values.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/arc-values.yaml
@@ -62,7 +62,7 @@ windows:
     pullPolicy: IfNotPresent
   nodeSelector: {}
   tolerations: []
-  enabled: false
+  enabled: true
   resources:
     requests:
       cpu: 100m
@@ -132,7 +132,7 @@ secrets-store-csi-driver:
       prometheus.io/port: "8080"
 
   windows:
-    enabled: false
+    enabled: true
     kubeletRootDir: C:\var\lib\kubelet
     metricsAddr: ":8080"
     image:

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer-windows.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/provider-azure-installer-windows.yaml
@@ -17,9 +17,17 @@ spec:
 {{- if .Values.windows.podLabels }}
 {{- toYaml .Values.windows.podLabels | nindent 8 }}
 {{- end }}
-{{- if .Values.windows.podAnnotations }}
+{{- if or .Values.windows.podAnnotations .Values.enableArcExtension }}
       annotations:
+{{- if .Values.windows.podAnnotations}}
 {{- toYaml .Values.windows.podAnnotations | nindent 8 }}
+{{- end }}
+{{- if .Values.enableArcExtension }}
+{{- if .Values.arc.enableMonitoring }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8898"
+{{- end }}
+{{- end }}
 {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}
@@ -61,6 +69,13 @@ spec:
             periodSeconds: 30
           resources:
 {{ toYaml .Values.windows.resources | indent 12 }}
+          {{- if .Values.enableArcExtension }}
+          {{- if .Values.Azure.proxySettings.isProxyEnabled }}
+          envFrom:
+            - secretRef:
+                name: arc-proxy-config
+          {{- end }}
+          {{- end }}
           volumeMounts:
             - name: provider-vol
               mountPath: "C:\\provider"


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->
This PR adds outbound proxy env variable support for windows pod
<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
