### PR TITLE
Automated cherry pick of #1082: chore: use base and test image from `registry.k8s.io`

### DIFF
--- a/arc/conformance/plugin/Dockerfile
+++ b/arc/conformance/plugin/Dockerfile
@@ -2,7 +2,7 @@ ARG STEP_CLI_VERSION=0.22.0
 ARG STEP_CLI_IMAGE=smallstep/step-cli:${STEP_CLI_VERSION}
 FROM $STEP_CLI_IMAGE as step-cli
 
-FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.4.1
+FROM registry.k8s.io/build-image/debian-base:bullseye-v1.4.2
 ARG KUBE_VERSION=v1.25.3
 ARG TARGETARCH
 

--- a/test/load/deployment-template.yaml
+++ b/test/load/deployment-template.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: pause
-        image: k8s.gcr.io/pause-amd64:3.1
+        image: registry.k8s.io/pause-amd64:3.1
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - name: secrets-store-inline


### PR DESCRIPTION
Cherry pick of #1082 on release-1.4.

#1082: chore: use base and test image from `registry.k8s.io`

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.