### PR TITLE
chore: use `dl.k8s.io` instead of hardcoded url

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -108,7 +108,7 @@ RUN mkdir -p /tmp/downloads/helm \
   && mv /tmp/downloads/helm/linux-amd64/helm /usr/local/bin
 
 # Install Kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl \
+RUN curl -LO https://dl.k8s.io/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl \
   && chmod +x ./kubectl \
   && mv kubectl /usr/bin/kubectl
 

--- a/.pipelines/templates/e2e-test-azure.yaml
+++ b/.pipelines/templates/e2e-test-azure.yaml
@@ -35,11 +35,11 @@ jobs:
 
       - script: |
           # Download kubectl
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+          curl -LO https://dl.k8s.io/release/`curl -s https://dl.k8s.io/release/stable.txt`/bin/linux/amd64/kubectl
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/
         displayName: 'Install kubectl'
-        
+
       - template: build-images.yaml
 
       - template: aks-setup.yaml

--- a/.pipelines/templates/soak-test.yaml
+++ b/.pipelines/templates/soak-test.yaml
@@ -21,7 +21,7 @@ jobs:
         - script: |
             # Download kubectl
             echo "Installing kubectl..."
-            curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+            curl -LO https://dl.k8s.io/release/`curl -s https://dl.k8s.io/release/stable.txt`/bin/linux/amd64/kubectl
             chmod +x kubectl
             sudo mv kubectl /usr/local/bin/
           displayName: "Install kubectl"

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ mod:
 
 .PHONY: install-kubectl
 install-kubectl:
-	curl -LO https://storage.googleapis.com/kubernetes-release/release/${KIND_K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv kubectl /usr/local/bin/
+	curl -LO https://dl.k8s.io/release/${KIND_K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv kubectl /usr/local/bin/
 
 .PHONY: e2e-bootstrap
 e2e-bootstrap: install-helm

--- a/arc/conformance/plugin/Dockerfile
+++ b/arc/conformance/plugin/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor >
     rm -rf /var/lib/apt/lists/*
 
 # install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${TARGETARCH}/kubectl && \
+RUN curl -LO https://dl.k8s.io/release/${KUBE_VERSION}/bin/linux/${TARGETARCH}/kubectl && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
The `storage.googleapis.com/kubernetes-release` URL is a hard coded path to a GCS bucket location. To allow redirecting and spreading the load across multiple hosting locations, the `dl.k8s.io` URL has been introduced.

xref: https://github.com/kubernetes/k8s.io/issues/2396