### PR TITLE
ci: fix kubectl download url

### DIFF
--- a/.pipelines/templates/e2e-test-azure.yaml
+++ b/.pipelines/templates/e2e-test-azure.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - script: |
           # Download kubectl
-          curl -LO https://dl.k8s.io/release/`curl -s https://dl.k8s.io/release/stable.txt`/bin/linux/amd64/kubectl
+          curl -LO https://dl.k8s.io/release/`curl -sL https://dl.k8s.io/release/stable.txt`/bin/linux/amd64/kubectl
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/
         displayName: 'Install kubectl'

--- a/.pipelines/templates/soak-test.yaml
+++ b/.pipelines/templates/soak-test.yaml
@@ -21,7 +21,7 @@ jobs:
         - script: |
             # Download kubectl
             echo "Installing kubectl..."
-            curl -LO https://dl.k8s.io/release/`curl -s https://dl.k8s.io/release/stable.txt`/bin/linux/amd64/kubectl
+            curl -LO https://dl.k8s.io/release/`curl -sL https://dl.k8s.io/release/stable.txt`/bin/linux/amd64/kubectl
             chmod +x kubectl
             sudo mv kubectl /usr/local/bin/
           displayName: "Install kubectl"


### PR DESCRIPTION
Add `-L` flag to the curl command to follow redirect while getting the latest stable version for kubectl.

```bash
➜ curl -s https://dl.k8s.io/release/stable.txt
<html>
<head><title>302 Found</title></head>
<body>
<center><h1>302 Found</h1></center>
<hr><center>nginx</center>
</body>
</html>

➜ curl -sL https://dl.k8s.io/release/stable.txt
v1.27.2
```