### PR TITLE
ci: fix `az aks get-versions` command failure

### DIFF
--- a/.pipelines/templates/aks-setup.yaml
+++ b/.pipelines/templates/aks-setup.yaml
@@ -18,15 +18,15 @@ steps:
       fi
     displayName: "Set cluster name"
     condition: succeeded()
-    
+
   - script: |
       echo "##vso[task.setvariable variable=NODE_VM_SIZE]Standard_DS2_v2"
     displayName: "Determine VM Size"
     condition: succeeded()
 
-  - script: | 
-      #Run test with latest on preview aks version available
-      aksVersion=$(az aks get-versions -l $(AZURE_LOCATION) --query "max(orchestrators[?isPreview==null&&orchestratorVersion>'1.20'].orchestratorVersion)" -otsv)
+  - script: |
+      # Run test with latest non-preview aks version available
+      aksVersion=$(az aks get-versions -l $(AZURE_LOCATION) --query 'values[?isPreview==null].patchVersions[]' | jq '[.[] | to_entries[] | .key ] | max')
       echo "AKS Install version - $aksVersion"
 
       echo "##vso[task.setvariable variable=AKS_INSTALL_VERSION]$aksVersion"
@@ -35,9 +35,9 @@ steps:
 
   - ${{ if eq(parameters.testClusterUpgrade, true) }}:
     # Overrride AKS_INSTALL_VERSION if testing with k8s upgrade
-    # If we are running test with cluster upgrade, start with minimum possible non preview version. 
+    # If we are running test with cluster upgrade, start with minimum possible non preview version.
     - script: |
-        aksVersion=$(az aks get-versions -l $(AZURE_LOCATION) --query "min(orchestrators[?isPreview==null&&orchestratorVersion>'1.20'].orchestratorVersion)" -otsv)
+        aksVersion=$(az aks get-versions -l $(AZURE_LOCATION) --query 'values[?isPreview==null].patchVersions[]' | jq '[.[] | to_entries[] | .key ] | min')
         echo "AKS Install version - $aksVersion"
 
         echo "##vso[task.setvariable variable=AKS_INSTALL_VERSION]$aksVersion"


### PR DESCRIPTION
The AKS LIST versions has API in azure-cli has been updated to latest and breaks compatibility. It no longer has `orchestrators[*].orchestratorVersion`. Refer to https://learn.microsoft.com/en-us/rest/api/aks/managed-clusters/list-kubernetes-versions?tabs=HTTP#kubernetesversionlistresult for sample result. 