### PR TITLE
fix: update fluentd env var with new env var name

### DIFF
--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/arc-monitoring.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/arc-monitoring.yaml
@@ -192,7 +192,7 @@ spec:
               cpu: 50m
               memory: 250Mi
           env:
-            - name: FLUENTD_CONF
+            - name: FLUENT_CONF
               value: /etc/fluentd/fluentd.conf
           volumeMounts:
             - name: fluentd-conf-vol


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

This change fixes an issue with `genevafluentd_td_agent:mariner_20230915.3`:

<img width="1442" alt="image" src="https://github.com/Azure/secrets-store-csi-driver-provider-azure/assets/111466195/a12649c8-bdaa-4380-8063-dfe093f33e70">

This image appears to use an updated version of `fluentd` where the `FLUENTD_CONF` is no longer supported. Instead, the environment variable is now [`FLUENT_CONF`](https://docs.fluentd.org/configuration/config-file#fluent_conf-environment-variable).

With this change, fluentd is able to find the `fluentd.conf` file:

<img width="1143" alt="image" src="https://github.com/Azure/secrets-store-csi-driver-provider-azure/assets/111466195/1b753651-1bd9-4a0c-b088-6c86ddcd618d">


**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
