### PR TITLE
ci: remove aks-preview pinned version and use cgv2 pool image for arc kind tests

### DIFF
--- a/.pipelines/templates/aks-setup.yaml
+++ b/.pipelines/templates/aks-setup.yaml
@@ -72,8 +72,7 @@ steps:
 
       if [[ "$(OS_TYPE)" == "windows" ]]; then
         if [[ ${{ parameters.containerRuntime }} == "containerd" ]]; then
-          # pinning to 0.5.87 because of https://github.com/Azure/azure-cli/issues/23267
-          az extension add --name aks-preview --version 0.5.87
+          az extension add --name aks-preview
           EXTRA_ARGS="--aks-custom-headers WindowsContainerRuntime=containerd"
         fi
 
@@ -83,8 +82,7 @@ steps:
       # add gpu node pool
       if [[ ${{ parameters.testWithGPU }} == True ]]; then
         echo "adding gpu node pool"
-        # pinning to 0.5.87 because of https://github.com/Azure/azure-cli/issues/23267
-        az extension add --name aks-preview --version 0.5.87
+        az extension add --name aks-preview
 
         az aks nodepool add -g ${AZURE_CLUSTER_NAME} --cluster-name ${AZURE_CLUSTER_NAME} --name gpu --node-count $(AGENT_COUNT) --node-vm-size Standard_NC6 --aks-custom-headers UseGPUDedicatedVHD=true
       fi

--- a/.pipelines/templates/arc/e2e-test-kind.yaml
+++ b/.pipelines/templates/arc/e2e-test-kind.yaml
@@ -1,5 +1,9 @@
 jobs:
   - job: e2e_arc_kind
+    pool:
+      name: staging-pool-amd64-mariner-2
+      demands:
+      - ImageOverride -equals azcu-agent-amd64-mariner-2-cgv2-img
     variables:
     - name: AZURE_ENVIRONMENT_FILEPATH
       value: /etc/kubernetes/custom_environment.json


### PR DESCRIPTION
- remove aks-preview pinned version
- use cgv2 pool image for arc kind tests