### PR TITLE
chore: bump trivy to 0.50.1

### DIFF
--- a/.pipelines/templates/scan-images.yaml
+++ b/.pipelines/templates/scan-images.yaml
@@ -1,8 +1,8 @@
 steps:
   - script: |
       # install trivy
-      wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION:-0.27.1}/trivy_${TRIVY_VERSION:-0.27.1}_Linux-64bit.tar.gz
-      tar zxvf trivy_${TRIVY_VERSION:-0.27.1}_Linux-64bit.tar.gz
+      wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION:-0.50.1}/trivy_${TRIVY_VERSION:-0.50.1}_Linux-64bit.tar.gz
+      tar zxvf trivy_${TRIVY_VERSION:-0.50.1}_Linux-64bit.tar.gz
 
       make container arc-conformance-container
       ./trivy image --reset
@@ -18,4 +18,4 @@ steps:
       REGISTRY: e2e
       IMAGE_VERSION: test
       OUTPUT_TYPE: docker
-      TRIVY_VERSION: $(TRIVY_VERSION)
+      TRIVY_VERSION: "0.50.1"


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
