### PR TITLE
ci: bump ossf/scorecard-action to v2.3.1

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@80e868c13c90f172d68d1f4501dee99e2479f7af # v2.1.3
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Updating `ossf/scorecard-action` to latest (v2.3.1) to resolves [failures](https://github.com/Azure/secrets-store-csi-driver-provider-azure/actions/runs/8696368466/job/23849474524).

xref: https://github.com/ossf/scorecard-action/issues/997