### PR TITLE
ci: cleanup windows pr gate

### DIFF
--- a/.pipelines/e2e-job-azure.yaml
+++ b/.pipelines/e2e-job-azure.yaml
@@ -18,8 +18,7 @@ jobs:
     parameters:
       osTypes:
       - "linux"
-      - "windows_docker"
-      - "windows_containerd"
+      - "windows"
   # TODO: re-enable this job after implementing automated ext release process
   # using https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/1382 for tracking
   # this will ensure any changes to provider works on arc extension too.

--- a/.pipelines/templates/aks-setup.yaml
+++ b/.pipelines/templates/aks-setup.yaml
@@ -5,9 +5,6 @@ parameters:
   - name: testWithGPU
     type: boolean
     default: false
-  - name: containerRuntime
-    type: string
-    default: containerd
 
 steps:
   - script: |
@@ -71,11 +68,6 @@ steps:
         echo "##vso[task.setvariable variable=MASTERINTERNALIP]${MASTERIP}"
 
       if [[ "$(OS_TYPE)" == "windows" ]]; then
-        if [[ ${{ parameters.containerRuntime }} == "containerd" ]]; then
-          az extension add --name aks-preview
-          EXTRA_ARGS="--aks-custom-headers WindowsContainerRuntime=containerd"
-        fi
-
         az aks nodepool add -g ${AZURE_CLUSTER_NAME} --cluster-name ${AZURE_CLUSTER_NAME} --os-type Windows --name win --node-count 1 ${EXTRA_ARGS:-} > /dev/null
       fi
 

--- a/.pipelines/templates/e2e-test-azure.yaml
+++ b/.pipelines/templates/e2e-test-azure.yaml
@@ -27,11 +27,7 @@ jobs:
           OS_TYPE=$(echo ${{ osType }} | cut -d '_' -f1 | tr -d '[:space:]')
           echo "OS type: $OS_TYPE"
           echo "##vso[task.setvariable variable=OS_TYPE]$OS_TYPE"
-
-          CONTAINER_RUNTIME=$(echo ${{ osType }} | cut -d '_' -f2 | tr -d '[:space:]')
-          echo "Container Runtime: $CONTAINER_RUNTIME"
-          echo "##vso[task.setvariable variable=CONTAINER_RUNTIME]$CONTAINER_RUNTIME"
-        displayName: 'Determine os type and container runtime'
+        displayName: 'Determine os type'
 
       - script: |
           # Download kubectl
@@ -46,7 +42,6 @@ jobs:
         parameters:
           testClusterUpgrade: ${{ parameters.testClusterUpgrade }}
           testWithGPU: ${{ parameters.testWithGPU }}
-          containerRuntime: $(CONTAINER_RUNTIME)
 
       - template: assign-user-identity.yaml
         parameters:


### PR DESCRIPTION
- The default container runtime is `containerd` in windows, so the `windows_containerd` job was a duplicate with steps that weren't required.