### PR TITLE
chore: v1.5.6 chart release to disable arc monitoring by default

### DIFF
--- a/charts/csi-secrets-store-provider-azure/Chart.yaml
+++ b/charts/csi-secrets-store-provider-azure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: csi-secrets-store-provider-azure
-version: 1.5.5
+version: 1.5.6
 appVersion: 1.5.3
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart to install the Secrets Store CSI Driver and the Azure Keyvault Provider inside a Kubernetes cluster.

--- a/charts/csi-secrets-store-provider-azure/arc-values.yaml
+++ b/charts/csi-secrets-store-provider-azure/arc-values.yaml
@@ -242,7 +242,7 @@ Azure:
 
 # Arc monitoring
 arc:
-  enableMonitoring: true
+  enableMonitoring: false
 
 # Port that serves metrics
 metricsAddr: "8898"

--- a/charts/csi-secrets-store-provider-azure/config/telegraf-conf.tmpl
+++ b/charts/csi-secrets-store-provider-azure/config/telegraf-conf.tmpl
@@ -13,7 +13,7 @@
   bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_ca = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
   insecure_skip_verify = true
-  response_timeout = "15s"
+  timeout = "15s"
 
 [[inputs.prometheus]]
   metric_version = 2
@@ -24,7 +24,7 @@
   bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_ca = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
   insecure_skip_verify = true
-  response_timeout = "15s"
+  timeout = "15s"
 
 [[outputs.http]]
   ## URL is the address to send metrics to

--- a/charts/csi-secrets-store-provider-azure/templates/arc-monitoring.yaml
+++ b/charts/csi-secrets-store-provider-azure/templates/arc-monitoring.yaml
@@ -83,7 +83,7 @@ spec:
             {{- end }}
         # Telegraf
         - name: telegraf
-          image: "mcr.microsoft.com/mirror/docker/library/telegraf:1.28"
+          image: "mcr.microsoft.com/cbl-mariner/base/telegraf:1.29"
           imagePullPolicy: IfNotPresent
           resources:
             {{- toYaml .Values.telegraf.resources | nindent 12 }}

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/Chart.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: csi-secrets-store-provider-azure
-version: 1.5.5
+version: 1.5.6
 appVersion: 1.5.3
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart to install the Secrets Store CSI Driver and the Azure Keyvault Provider inside a Kubernetes cluster.


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [ ] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
