### PR TITLE
ci: update `az aks get-versions` command query

### DIFF
--- a/.pipelines/templates/aks-setup.yaml
+++ b/.pipelines/templates/aks-setup.yaml
@@ -23,7 +23,7 @@ steps:
 
   - script: |
       # Run test with latest non-preview aks version available
-      aksVersion=$(az aks get-versions -l $(AZURE_LOCATION) --query 'values[?isPreview==null].patchVersions[]' | jq '[.[] | to_entries[] | .key ] | max')
+      aksVersion=$(az aks get-versions -l $(AZURE_LOCATION) --query 'values[?!(contains(capabilities.supportPlan, 'AKSLongTermSupport')) && isPreview==null].patchVersions | []' | jq '[.[] | to_entries[] | .key ] | max')
       echo "AKS Install version - $aksVersion"
 
       echo "##vso[task.setvariable variable=AKS_INSTALL_VERSION]$aksVersion"
@@ -34,7 +34,7 @@ steps:
     # Overrride AKS_INSTALL_VERSION if testing with k8s upgrade
     # If we are running test with cluster upgrade, start with minimum possible non preview version.
     - script: |
-        aksVersion=$(az aks get-versions -l $(AZURE_LOCATION) --query 'values[?isPreview==null].patchVersions[]' | jq '[.[] | to_entries[] | .key ] | min')
+        aksVersion=$(az aks get-versions -l $(AZURE_LOCATION) --query 'values[?!(contains(capabilities.supportPlan, 'AKSLongTermSupport')) && isPreview==null].patchVersions | []' | jq '[.[] | to_entries[] | .key ] | min')
         echo "AKS Install version - $aksVersion"
 
         echo "##vso[task.setvariable variable=AKS_INSTALL_VERSION]$aksVersion"


### PR DESCRIPTION
fixes nightly CI failures
```bash
ERROR: (K8sVersionNotSupported) Managed cluster sscd-e2e-ec52ce9341f2 is on version 1.27.1, which is only available for Long-Term Support (LTS). If you intend to onboard to LTS, please ensure the cluster is in Premium tier and LTS support plan (see https://aka.ms/aks/enable-lts). Otherwise, use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list
Code: K8sVersionNotSupported
```