### PR TITLE
ci: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -63,7 +63,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Scorecards action run is failing because `v3` of `actions/upload-artifact` is deprecated. Bumping it to `v4`.

ref: https://github.com/Azure/secrets-store-csi-driver-provider-azure/actions/runs/14138326613/job/39615056456