### PR TITLE
docs: Fixed links to access mode pages

### DIFF
--- a/website/content/en/getting-started/usage/_index.md
+++ b/website/content/en/getting-started/usage/_index.md
@@ -88,11 +88,11 @@ To provide identity to access Key Vault, refer to the following [section](#provi
 
 The Azure Key Vault Provider offers five modes for accessing a Key Vault instance:
 
-1. [Service Principal](../../configurations/identity-access-modes/service-principal-mode) ** This is currently the only way to connect to Azure Key Vault from a non Azure environment.
-2. [Pod Identity](../../configurations/identity-access-modes/pod-identity-mode)
-3. [User-assigned Managed Identity](../../configurations/identity-access-modes/user-assigned-msi-mode)
-4. [System-assigned Managed Identity](../../configurations/identity-access-modes/system-assigned-msi-mode)
-5. [Workload Identity](../../configurations/identity-access-modes/workload-identity-mode)
+1. [Service Principal](../../configurations/identity-access-modes/service-principal-mode.md) ** This is currently the only way to connect to Azure Key Vault from a non Azure environment.
+2. [Pod Identity](../../configurations/identity-access-modes/pod-identity-mode.md)
+3. [User-assigned Managed Identity](../../configurations/identity-access-modes/user-assigned-msi-mode.md)
+4. [System-assigned Managed Identity](../../configurations/identity-access-modes/system-assigned-msi-mode.md)
+5. [Workload Identity](../../configurations/identity-access-modes/workload-identity-mode.md)
 
 #### Update your Deployment Yaml
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
Links lead to 404 - page not found.

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [ ] squashed commits
- [ ] included documentation
- [ ] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
