### PR TITLE
chore: update to go 1.24.7

### DIFF
--- a/.pipelines/templates/e2e-test-azure.yaml
+++ b/.pipelines/templates/e2e-test-azure.yaml
@@ -25,7 +25,7 @@ jobs:
       steps:
       - task: GoTool@0
         inputs:
-          version: '1.24.6'
+          version: '1.24.7'
 
       - script: |
           OS_TYPE=$(echo ${{ osType }} | cut -d '_' -f1 | tr -d '[:space:]')

--- a/.pipelines/templates/e2e-test-kind.yaml
+++ b/.pipelines/templates/e2e-test-kind.yaml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: '1.24.6'
+          version: '1.24.7'
       # logging in to download the sa.pub and sa.key used for creating the kind cluster
       # with OIDC issuer enabled
       - template: az-login.yaml

--- a/.pipelines/templates/unit-test.yaml
+++ b/.pipelines/templates/unit-test.yaml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: '1.24.6'
+          version: '1.24.7'
       - script: make lint
         displayName: golangci-lint
       - script: make helm-lint
@@ -20,7 +20,7 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: '1.24.6'
+          version: '1.24.7'
       - script: make build build-windows
         displayName: build
   - job: unit_test
@@ -30,6 +30,6 @@ jobs:
     steps:
       - task: GoTool@0
         inputs:
-          version: '1.24.6'
+          version: '1.24.7'
       - script: make unit-test
         displayName: unit test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/secrets-store-csi-driver-provider-azure
 
-go 1.24.6
+go 1.24.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e
 
-go 1.24.6
+go 1.24.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/secrets-store-csi-driver-provider-azure/tools
 
-go 1.24.6
+go 1.24.7
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
Cherry pick of #1934 on release-1.7.

#1934: chore: update to go 1.24.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.