### PR TITLE
docs: add identity binding documentation

### DIFF
--- a/website/content/en/configurations/identity-access-modes/_index.md
+++ b/website/content/en/configurations/identity-access-modes/_index.md
@@ -4,7 +4,7 @@ title: "Identity Access Modes"
 linkTitle: "Identity Access Modes"
 weight: 1
 description: >
-  The Azure Key Vault Provider offers four modes for accessing a Key Vault instance
+  The Azure Key Vault Provider offers five modes for accessing a Key Vault instance
 ---
 
 ## Best Practices
@@ -13,7 +13,8 @@ Following order of access modes is recommended for Secret Store CSI driver AKV p
 
 | Access Option                                          | Comment                                                                                                                                                                                                                                                                    |
 | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Workload Identity [**RECOMMENDED**]                    | This is the most secure way to access Key Vault based on the [Workload Identity Federation](https://docs.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation).                                                                                 |
-| Pod Identity [**NOT RECOMMENDED**]                     | [AAD Pod Identity](https://github.com/Azure/aad-pod-identity) has been [DEPRECATED](https://github.com/Azure/aad-pod-identity#-announcement).<br>This provides a way to get access to Azure resources (AKV in this case) using the managed identity bound to the Pod.</br> |
+| Identity Binding [**RECOMMENDED for AKS**]             | Uses [AKS Identity Binding](https://learn.microsoft.com/azure/aks/identity-bindings-concepts) to access Key Vault. Only requires a single FIC on the managed identity regardless of how many clusters or workloads use it, eliminating workload identity's 20 FIC-per-identity limit. AKS only. |
+| Workload Identity [**RECOMMENDED**]                    | Access Key Vault using [Workload Identity Federation](https://docs.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation). Works on any Kubernetes cluster with an OIDC issuer.                                                                   |
+| Pod Identity [**DEPRECATED**]                          | [AAD Pod Identity](https://github.com/Azure/aad-pod-identity) has been [DEPRECATED](https://github.com/Azure/aad-pod-identity#-announcement).<br>This provides a way to get access to Azure resources (AKV in this case) using the managed identity bound to the Pod.</br> |
 | Managed Identities (System-assigned and User-assigned) | Managed identities eliminate the need for developers to manage credentials. Managed identities provide an identity for applications to use when connecting to Azure Keyvault.                                                                                              |
 | Service Principal                                      | This is the last option to consider while connecting to AKV as access credentials need to be created as Kubernetes Secret and stored in plain text in etcd.                                                                                                                |

--- a/website/content/en/configurations/identity-access-modes/identity-binding-mode.md
+++ b/website/content/en/configurations/identity-access-modes/identity-binding-mode.md
@@ -1,0 +1,141 @@
+---
+type: docs
+title: "Identity Binding"
+linkTitle: "Identity Binding"
+weight: 0
+description: >
+  Use Identity Binding to access Key Vault on AKS.
+---
+
+{{% alert title="AKS Only" color="info" %}}
+Identity binding is only available on Azure Kubernetes Service (AKS) clusters.
+{{% /alert %}}
+
+Identity binding is an AKS-specific auth mode that eliminates a key limitation of [workload identity](../workload-identity-mode): the **20 federated identity credential (FIC) cap per managed identity**. With workload identity, each combination of namespace, service account, and cluster requires its own FIC since each cluster has a unique issuer, which means a single managed identity can only be used by 20 unique workloads across all clusters. Identity binding requires only a single FIC on the managed identity regardless of how many clusters or workloads use it, so any number of workloads can share a managed identity without per-workload credential management.
+
+For more details on identity binding concepts, see the [AKS identity binding documentation](https://learn.microsoft.com/azure/aks/identity-bindings-concepts).
+
+<details>
+<summary>Examples</summary>
+
+- `SecretProviderClass`
+```yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: azure-kvname-idb
+spec:
+  provider: azure
+  parameters:
+    useAzureTokenProxy: "true"
+    clientID: "<client id of the user-assigned managed identity>"
+    keyvaultName: "kvname"
+    objects:  |
+      array:
+        - |
+          objectName: secret1
+          objectType: secret
+          objectVersion: ""
+        - |
+          objectName: key1
+          objectType: key
+          objectVersion: ""
+    tenantID: "tid"
+```
+
+- `Pod` yaml
+```yaml
+kind: Pod
+apiVersion: v1
+metadata:
+  name: busybox-secrets-store-inline-idb
+spec:
+  serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+  containers:
+    - name: busybox
+      image: registry.k8s.io/e2e-test-images/busybox:1.29-4
+      command:
+        - "/bin/sleep"
+        - "10000"
+      volumeMounts:
+      - name: secrets-store01-inline
+        mountPath: "/mnt/secrets-store"
+        readOnly: true
+  volumes:
+    - name: secrets-store01-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "azure-kvname-idb"
+```
+</details>
+
+## Prerequisites
+
+- AKS cluster
+- Azure CLI version `2.40.0` or higher
+- A user-assigned managed identity with access to the Key Vault
+- An [AKS identity binding](https://learn.microsoft.com/azure/aks/identity-bindings-concepts) resource created for the managed identity
+
+## Configure Identity Binding to access Key Vault
+
+### 1. Create a managed identity and grant Key Vault access
+
+Create a user-assigned managed identity and grant it access to your Key Vault:
+
+```bash
+export RESOURCE_GROUP=<resource group name>
+export USER_ASSIGNED_IDENTITY_NAME="<your managed identity name>"
+export KEYVAULT_NAME="<your key vault name>"
+
+az identity create -g ${RESOURCE_GROUP} -n ${USER_ASSIGNED_IDENTITY_NAME}
+export USER_ASSIGNED_IDENTITY_CLIENT_ID=$(az identity show -g ${RESOURCE_GROUP} -n ${USER_ASSIGNED_IDENTITY_NAME} --query clientId -otsv)
+
+# Grant Key Vault access
+az keyvault set-policy -n $KEYVAULT_NAME --key-permissions get --spn ${USER_ASSIGNED_IDENTITY_CLIENT_ID}
+az keyvault set-policy -n $KEYVAULT_NAME --secret-permissions get --spn ${USER_ASSIGNED_IDENTITY_CLIENT_ID}
+az keyvault set-policy -n $KEYVAULT_NAME --certificate-permissions get --spn ${USER_ASSIGNED_IDENTITY_CLIENT_ID}
+```
+
+### 2. Create the identity binding and configure RBAC
+
+Follow the [AKS identity binding documentation](https://learn.microsoft.com/azure/aks/identity-bindings-concepts) to:
+
+1. Create an identity binding resource for your AKS cluster
+2. Create the required Kubernetes RBAC (ClusterRole and ClusterRoleBinding) to authorize your service account to use the managed identity
+
+### 3. Deploy your SecretProviderClass and application
+
+Set `useAzureTokenProxy: "true"` and the `clientID` to the managed identity's client ID in the `SecretProviderClass`:
+
+```yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: azure-kvname-idb
+spec:
+  provider: azure
+  parameters:
+    useAzureTokenProxy: "true"
+    clientID: "${USER_ASSIGNED_IDENTITY_CLIENT_ID}"
+    keyvaultName: "${KEYVAULT_NAME}"
+    tenantID: "${TENANT_ID}"
+    objects: |
+      array:
+        - |
+          objectName: secret1
+          objectType: secret
+```
+
+Deploy a pod with a service account that has the identity binding RBAC configured in step 2.
+
+{{% alert title="Note" color="info" %}}
+If you are installing the Secrets Store CSI Driver using raw manifests instead of the Helm chart, ensure the `CSIDriver` resource includes `api://AKSIdentityBinding` in the `tokenRequests` field. The Helm chart includes this by default.
+{{% /alert %}}
+
+## Pros
+
+1. **No per-workload FIC**: Only a single FIC on the managed identity is needed regardless of how many clusters or workloads use it, unlike workload identity which requires one per namespace, service account, and cluster combination (capped at 20 per identity).
+2. **No per-workload credential management**: New workloads can use a managed identity without creating individual FICs.
+3. Supported on both Windows and Linux.

--- a/website/content/en/getting-started/usage/_index.md
+++ b/website/content/en/getting-started/usage/_index.md
@@ -69,7 +69,8 @@ To provide identity to access Key Vault, refer to the following [section](#provi
   | usePodIdentity         | no       | set to true for using aad-pod-identity to access keyvault                                                                                                                                                              | "false"       |
   | useVMManagedIdentity   | no       | [__*available for version > 0.0.4*__] specify access mode to enable use of User-assigned managed identity                                                                                                              | "false"       |
   | userAssignedIdentityID | no       | [__*available for version > 0.0.4*__] the user assigned identity ID is required for User-assigned Managed Identity mode                                                                                                | ""            |
-  | clientID | no       | [__*available for version > 1.1.0*__] client id of the Azure AD Application or managed identity to use for workload identity                                                                                                | ""            |
+  | clientID | no       | client id of the managed identity or Azure AD Application for workload identity; must be a managed identity client id for identity binding                                                                                                | ""            |
+  | useAzureTokenProxy     | no       | set to true for using identity binding to access keyvault (AKS only)                                                                                                                                                   | "false"       |
   | keyvaultName           | yes      | name of a Key Vault instance                                                                                                                                                                                           | ""            |
   | cloudName              | no       | [__*available for version > 0.0.4*__] name of the azure cloud based on azure go sdk (AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, AzureGermanCloud, AzureStackCloud)                                     | ""            |
   | cloudEnvFileName       | no       | [__*available for version > 0.0.7*__] path to the file to be used while populating the Azure Environment (required if target cloud is AzureStackCloud). More details [here](../../configurations/custom-environments). | ""            |
@@ -86,13 +87,14 @@ To provide identity to access Key Vault, refer to the following [section](#provi
 
 #### Provide Identity to Access Key Vault
 
-The Azure Key Vault Provider offers five modes for accessing a Key Vault instance:
+The Azure Key Vault Provider offers six modes for accessing a Key Vault instance:
 
-1. [Service Principal](../../configurations/identity-access-modes/service-principal-mode) ** This is currently the only way to connect to Azure Key Vault from a non Azure environment.
-2. [Pod Identity](../../configurations/identity-access-modes/pod-identity-mode)
-3. [User-assigned Managed Identity](../../configurations/identity-access-modes/user-assigned-msi-mode)
-4. [System-assigned Managed Identity](../../configurations/identity-access-modes/system-assigned-msi-mode)
-5. [Workload Identity](../../configurations/identity-access-modes/workload-identity-mode)
+1. [Identity Binding](../../configurations/identity-access-modes/identity-binding-mode) **RECOMMENDED for AKS** - Only a single FIC on the managed identity needed instead of one per workload.
+2. [Workload Identity](../../configurations/identity-access-modes/workload-identity-mode) **RECOMMENDED** - Works on any Kubernetes cluster with an OIDC issuer.
+3. [Service Principal](../../configurations/identity-access-modes/service-principal-mode) ** This is currently the only way to connect to Azure Key Vault from a non Azure environment.
+4. [Pod Identity](../../configurations/identity-access-modes/pod-identity-mode) **DEPRECATED**
+5. [User-assigned Managed Identity](../../configurations/identity-access-modes/user-assigned-msi-mode)
+6. [System-assigned Managed Identity](../../configurations/identity-access-modes/system-assigned-msi-mode)
 
 #### Update your Deployment Yaml
 


### PR DESCRIPTION
Add documentation for the identity binding auth mode. Identity binding is the recommended way to access Key Vault on AKS and removes the 20 FIC-per-identity limit that workload identity has.