### PR TITLE
fix: only set managed identity client ID when non-empty

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -287,8 +287,9 @@ func getServicePrincipalTokenCredential(clientID, secret, aadEndpoint, tenantID 
 }
 
 func getManagedIdentityTokenCredential(identityClientID string) (azcore.TokenCredential, error) {
-	opts := &azidentity.ManagedIdentityCredentialOptions{
-		ID: azidentity.ClientID(identityClientID),
+	opts := &azidentity.ManagedIdentityCredentialOptions{}
+	if len(identityClientID) > 0 {
+		opts.ID = azidentity.ClientID(identityClientID)
 	}
 	return azidentity.NewManagedIdentityCredential(opts)
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -336,3 +336,31 @@ func TestGetCredential_IdentityBinding_MissingFields(t *testing.T) {
 		})
 	}
 }
+
+func TestGetManagedIdentityTokenCredential(t *testing.T) {
+	tests := []struct {
+		name             string
+		identityClientID string
+	}{
+		{
+			name:             "system-assigned identity with empty client ID",
+			identityClientID: "",
+		},
+		{
+			name:             "user-assigned identity with client ID",
+			identityClientID: "user-assigned-client-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cred, err := getManagedIdentityTokenCredential(tt.identityClientID)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cred == nil {
+				t.Fatal("expected non-nil credential")
+			}
+		})
+	}
+}


### PR DESCRIPTION
When using system-assigned managed identity, the client_id is empty. The Azure SDK treats an empty ClientID as a user-assigned identity request, causing authentication failures for system-assigned identity.

This seems to be related to https://github.com/AzureAD/microsoft-authentication-library-for-go/pull/552
this is the error https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/b4b8bfc9569042572ccb82b648ea509075fadb74/apps/managedidentity/managedidentity.go#L249

The bumped sdk is basically breaking the system-assigned identity option.

Unit test failure without fix

```
  === RUN   TestGetManagedIdentityTokenCredential
  === RUN   TestGetManagedIdentityTokenCredential/system-assigned_identity_with_empty_client_ID
      auth_test.go:359: unexpected error: empty managedidentity.UserAssignedClientID
  --- FAIL: TestGetManagedIdentityTokenCredential (0.00s)
      --- FAIL: TestGetManagedIdentityTokenCredential/system-assigned_identity_with_empty_client_ID (0.00s)
  FAIL
```