### PR TITLE
fix: only set managed identity client ID when non-empty

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -287,8 +287,9 @@ func getServicePrincipalTokenCredential(clientID, secret, aadEndpoint, tenantID 
 }
 
 func getManagedIdentityTokenCredential(identityClientID string) (azcore.TokenCredential, error) {
-	opts := &azidentity.ManagedIdentityCredentialOptions{
-		ID: azidentity.ClientID(identityClientID),
+	opts := &azidentity.ManagedIdentityCredentialOptions{}
+	if len(identityClientID) > 0 {
+		opts.ID = azidentity.ClientID(identityClientID)
 	}
 	return azidentity.NewManagedIdentityCredential(opts)
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -336,3 +336,31 @@ func TestGetCredential_IdentityBinding_MissingFields(t *testing.T) {
 		})
 	}
 }
+
+func TestGetManagedIdentityTokenCredential(t *testing.T) {
+	tests := []struct {
+		name             string
+		identityClientID string
+	}{
+		{
+			name:             "system-assigned identity with empty client ID",
+			identityClientID: "",
+		},
+		{
+			name:             "user-assigned identity with client ID",
+			identityClientID: "user-assigned-client-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cred, err := getManagedIdentityTokenCredential(tt.identityClientID)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cred == nil {
+				t.Fatal("expected non-nil credential")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #2021 on release-1.8.

#2021: fix: only set managed identity client ID when non-empty

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.