### PR TITLE
fix: set ErrorStream and InfoStream for JSON logger to avoid nil panic

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/utils"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/version"
 
+	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	logsapi "k8s.io/component-base/logs/api/v1"
@@ -70,8 +71,7 @@ func main() {
 	signal.Notify(signalChan, syscall.SIGTERM, syscall.SIGINT, os.Interrupt)
 
 	if *logFormatJSON {
-		jsonFactory := json.Factory{}
-		logger, _ := jsonFactory.Create(logsapi.LoggingConfiguration{Format: "json"}, logsapi.LoggingOptions{})
+		logger := newJSONLogger()
 		klog.SetLogger(logger)
 	}
 
@@ -174,4 +174,16 @@ func main() {
 	// gracefully stop the grpc server
 	klog.Infof("terminating the server")
 	s.GracefulStop()
+}
+
+// newJSONLogger creates a JSON logger with proper stream configuration.
+// ErrorStream and InfoStream must be set explicitly to avoid nil pointer
+// dereference in component-base's json.Factory.Create.
+func newJSONLogger() logr.Logger {
+	jsonFactory := json.Factory{}
+	logger, _ := jsonFactory.Create(logsapi.LoggingConfiguration{Format: "json"}, logsapi.LoggingOptions{
+		ErrorStream: os.Stderr,
+		InfoStream:  os.Stdout,
+	})
+	return logger
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestNewJSONLogger(t *testing.T) {
+	// newJSONLogger must not panic. Before the fix, passing empty
+	// LoggingOptions (nil ErrorStream/InfoStream) caused a nil pointer
+	// dereference inside component-base's json writer on the first
+	// Write call.
+	logger := newJSONLogger()
+	if logger.GetSink() == nil {
+		t.Fatal("expected logger to have a non-nil sink")
+	}
+
+	// Verify the logger can actually write without panicking.
+	logger.Info("test message", "key", "value")
+}


### PR DESCRIPTION
component-base v0.34.2 does not default nil streams to os.Stderr/os.Stdout, causing a nil pointer dereference on the first log write.

caught in CI here: https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_secrets-store-csi-driver/2034/pull-secrets-store-csi-driver-e2e-azure/2049222714106843136/artifacts/2026-04-28T204442-provider.logs

broken since https://github.com/Azure/secrets-store-csi-driver-provider-azure/pull/1962