### PR TITLE
feat: add `ValidatingAdmissionPolicy` for Azure SecretProviderClass

### DIFF
--- a/deployment/validatingadmissionpolicy.yaml
+++ b/deployment/validatingadmissionpolicy.yaml
@@ -1,0 +1,68 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: azure-secretproviderclass-validation
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["secrets-store.csi.x-k8s.io"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["secretproviderclasses"]
+  matchConditions:
+    - name: is-azure-provider
+      expression: "object.spec.provider == 'azure'"
+  validations:
+    # keyvaultName required, 3-24 chars, alphanumeric + hyphens
+    - expression: >-
+        has(object.spec.parameters.keyvaultName) &&
+        size(object.spec.parameters.keyvaultName.trim()) >= 3 &&
+        size(object.spec.parameters.keyvaultName.trim()) <= 24 &&
+        object.spec.parameters.keyvaultName.trim().matches('^[-A-Za-z0-9]+$')
+      message: "keyvaultName is required and must be 3-24 alphanumeric/hyphen characters"
+    # tenantId or tenantID required and non-empty
+    - expression: >-
+        (has(object.spec.parameters.tenantId) && size(object.spec.parameters.tenantId.trim()) > 0) ||
+        (has(object.spec.parameters.tenantID) && size(object.spec.parameters.tenantID.trim()) > 0)
+      message: "tenantId or tenantID is required"
+    # usePodIdentity must be valid boolean string
+    - expression: >-
+        !has(object.spec.parameters.usePodIdentity) ||
+        object.spec.parameters.usePodIdentity.trim() in ['true', 'false', '']
+      message: "usePodIdentity must be 'true' or 'false'"
+    # useVMManagedIdentity must be valid boolean string
+    - expression: >-
+        !has(object.spec.parameters.useVMManagedIdentity) ||
+        object.spec.parameters.useVMManagedIdentity.trim() in ['true', 'false', '']
+      message: "useVMManagedIdentity must be 'true' or 'false'"
+    # useAzureTokenProxy must be valid boolean string
+    - expression: >-
+        !has(object.spec.parameters.useAzureTokenProxy) ||
+        object.spec.parameters.useAzureTokenProxy.trim() in ['true', 'false', '']
+      message: "useAzureTokenProxy must be 'true' or 'false'"
+    # At most one identity mode boolean flag enabled
+    - expression: >-
+        (has(object.spec.parameters.usePodIdentity) && object.spec.parameters.usePodIdentity.trim() == 'true' ? 1 : 0) +
+        (has(object.spec.parameters.useVMManagedIdentity) && object.spec.parameters.useVMManagedIdentity.trim() == 'true' ? 1 : 0) +
+        (has(object.spec.parameters.useAzureTokenProxy) && object.spec.parameters.useAzureTokenProxy.trim() == 'true' ? 1 : 0) <= 1
+      message: "only one identity mode can be enabled at a time: usePodIdentity, useVMManagedIdentity, or useAzureTokenProxy"
+    # clientID required when useAzureTokenProxy is true
+    - expression: >-
+        !(has(object.spec.parameters.useAzureTokenProxy) && object.spec.parameters.useAzureTokenProxy.trim() == 'true') ||
+        (has(object.spec.parameters.clientID) && size(object.spec.parameters.clientID.trim()) > 0)
+      message: "clientID is required when useAzureTokenProxy is true"
+    # cloudName must be a known value
+    - expression: >-
+        !has(object.spec.parameters.cloudName) ||
+        object.spec.parameters.cloudName.trim() in ['', 'AzurePublicCloud', 'AzureChinaCloud', 'AzureGermanCloud', 'AzureUSGovernmentCloud', 'AzureStackCloud']
+      message: "cloudName must be one of: AzurePublicCloud, AzureChinaCloud, AzureGermanCloud, AzureUSGovernmentCloud, AzureStackCloud"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: azure-secretproviderclass-validation
+spec:
+  policyName: azure-secretproviderclass-validation
+  validationActions:
+    - Deny

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/validatingadmissionpolicy.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/validatingadmissionpolicy.yaml
@@ -3,8 +3,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: azure-secretproviderclass-validation
-  labels:
-    {{- include "sscdpa.labels" . | nindent 4 }}
+{{ include "sscdpa.labels" . | indent 2 }}
 spec:
   failurePolicy: Fail
   matchConstraints:
@@ -65,8 +64,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: azure-secretproviderclass-validation
-  labels:
-    {{- include "sscdpa.labels" . | nindent 4 }}
+{{ include "sscdpa.labels" . | indent 2 }}
 spec:
   policyName: azure-secretproviderclass-validation
   validationActions:

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/templates/validatingadmissionpolicy.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/templates/validatingadmissionpolicy.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.validatingAdmissionPolicy.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: azure-secretproviderclass-validation
+  labels:
+    {{- include "sscdpa.labels" . | nindent 4 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["secrets-store.csi.x-k8s.io"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["secretproviderclasses"]
+  matchConditions:
+    - name: is-azure-provider
+      expression: "object.spec.provider == 'azure'"
+  validations:
+    # keyvaultName required, 3-24 chars, alphanumeric + hyphens
+    - expression: >-
+        has(object.spec.parameters.keyvaultName) &&
+        size(object.spec.parameters.keyvaultName.trim()) >= 3 &&
+        size(object.spec.parameters.keyvaultName.trim()) <= 24 &&
+        object.spec.parameters.keyvaultName.trim().matches('^[-A-Za-z0-9]+$')
+      message: "keyvaultName is required and must be 3-24 alphanumeric/hyphen characters"
+    # tenantId or tenantID required and non-empty
+    - expression: >-
+        (has(object.spec.parameters.tenantId) && size(object.spec.parameters.tenantId.trim()) > 0) ||
+        (has(object.spec.parameters.tenantID) && size(object.spec.parameters.tenantID.trim()) > 0)
+      message: "tenantId or tenantID is required"
+    # usePodIdentity must be valid boolean string
+    - expression: >-
+        !has(object.spec.parameters.usePodIdentity) ||
+        object.spec.parameters.usePodIdentity.trim() in ['true', 'false', '']
+      message: "usePodIdentity must be 'true' or 'false'"
+    # useVMManagedIdentity must be valid boolean string
+    - expression: >-
+        !has(object.spec.parameters.useVMManagedIdentity) ||
+        object.spec.parameters.useVMManagedIdentity.trim() in ['true', 'false', '']
+      message: "useVMManagedIdentity must be 'true' or 'false'"
+    # useAzureTokenProxy must be valid boolean string
+    - expression: >-
+        !has(object.spec.parameters.useAzureTokenProxy) ||
+        object.spec.parameters.useAzureTokenProxy.trim() in ['true', 'false', '']
+      message: "useAzureTokenProxy must be 'true' or 'false'"
+    # At most one identity mode boolean flag enabled
+    - expression: >-
+        (has(object.spec.parameters.usePodIdentity) && object.spec.parameters.usePodIdentity.trim() == 'true' ? 1 : 0) +
+        (has(object.spec.parameters.useVMManagedIdentity) && object.spec.parameters.useVMManagedIdentity.trim() == 'true' ? 1 : 0) +
+        (has(object.spec.parameters.useAzureTokenProxy) && object.spec.parameters.useAzureTokenProxy.trim() == 'true' ? 1 : 0) <= 1
+      message: "only one identity mode can be enabled at a time: usePodIdentity, useVMManagedIdentity, or useAzureTokenProxy"
+    # clientID required when useAzureTokenProxy is true
+    - expression: >-
+        !(has(object.spec.parameters.useAzureTokenProxy) && object.spec.parameters.useAzureTokenProxy.trim() == 'true') ||
+        (has(object.spec.parameters.clientID) && size(object.spec.parameters.clientID.trim()) > 0)
+      message: "clientID is required when useAzureTokenProxy is true"
+    # cloudName must be a known value
+    - expression: >-
+        !has(object.spec.parameters.cloudName) ||
+        object.spec.parameters.cloudName.trim() in ['', 'AzurePublicCloud', 'AzureChinaCloud', 'AzureGermanCloud', 'AzureUSGovernmentCloud', 'AzureStackCloud']
+      message: "cloudName must be one of: AzurePublicCloud, AzureChinaCloud, AzureGermanCloud, AzureUSGovernmentCloud, AzureStackCloud"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: azure-secretproviderclass-validation
+  labels:
+    {{- include "sscdpa.labels" . | nindent 4 }}
+spec:
+  policyName: azure-secretproviderclass-validation
+  validationActions:
+    - Deny
+{{- end }}

--- a/manifest_staging/charts/csi-secrets-store-provider-azure/values.yaml
+++ b/manifest_staging/charts/csi-secrets-store-provider-azure/values.yaml
@@ -182,5 +182,9 @@ constructPEMChain: true
 # Write cert and key in separate files. The individual files will be named as <secret-name>.crt and <secret-name>.key. These files will be created in addition to the single file.
 writeCertAndKeyInSeparateFiles: false
 
+# Validating admission policy for SecretProviderClass validation
+validatingAdmissionPolicy:
+  enabled: true
+
 # Port that serves metrics
 metricsAddr: "8898"

--- a/manifest_staging/deployment/validatingadmissionpolicy.yaml
+++ b/manifest_staging/deployment/validatingadmissionpolicy.yaml
@@ -1,0 +1,68 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: azure-secretproviderclass-validation
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["secrets-store.csi.x-k8s.io"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["secretproviderclasses"]
+  matchConditions:
+    - name: is-azure-provider
+      expression: "object.spec.provider == 'azure'"
+  validations:
+    # keyvaultName required, 3-24 chars, alphanumeric + hyphens
+    - expression: >-
+        has(object.spec.parameters.keyvaultName) &&
+        size(object.spec.parameters.keyvaultName.trim()) >= 3 &&
+        size(object.spec.parameters.keyvaultName.trim()) <= 24 &&
+        object.spec.parameters.keyvaultName.trim().matches('^[-A-Za-z0-9]+$')
+      message: "keyvaultName is required and must be 3-24 alphanumeric/hyphen characters"
+    # tenantId or tenantID required and non-empty
+    - expression: >-
+        (has(object.spec.parameters.tenantId) && size(object.spec.parameters.tenantId.trim()) > 0) ||
+        (has(object.spec.parameters.tenantID) && size(object.spec.parameters.tenantID.trim()) > 0)
+      message: "tenantId or tenantID is required"
+    # usePodIdentity must be valid boolean string
+    - expression: >-
+        !has(object.spec.parameters.usePodIdentity) ||
+        object.spec.parameters.usePodIdentity.trim() in ['true', 'false', '']
+      message: "usePodIdentity must be 'true' or 'false'"
+    # useVMManagedIdentity must be valid boolean string
+    - expression: >-
+        !has(object.spec.parameters.useVMManagedIdentity) ||
+        object.spec.parameters.useVMManagedIdentity.trim() in ['true', 'false', '']
+      message: "useVMManagedIdentity must be 'true' or 'false'"
+    # useAzureTokenProxy must be valid boolean string
+    - expression: >-
+        !has(object.spec.parameters.useAzureTokenProxy) ||
+        object.spec.parameters.useAzureTokenProxy.trim() in ['true', 'false', '']
+      message: "useAzureTokenProxy must be 'true' or 'false'"
+    # At most one identity mode boolean flag enabled
+    - expression: >-
+        (has(object.spec.parameters.usePodIdentity) && object.spec.parameters.usePodIdentity.trim() == 'true' ? 1 : 0) +
+        (has(object.spec.parameters.useVMManagedIdentity) && object.spec.parameters.useVMManagedIdentity.trim() == 'true' ? 1 : 0) +
+        (has(object.spec.parameters.useAzureTokenProxy) && object.spec.parameters.useAzureTokenProxy.trim() == 'true' ? 1 : 0) <= 1
+      message: "only one identity mode can be enabled at a time: usePodIdentity, useVMManagedIdentity, or useAzureTokenProxy"
+    # clientID required when useAzureTokenProxy is true
+    - expression: >-
+        !(has(object.spec.parameters.useAzureTokenProxy) && object.spec.parameters.useAzureTokenProxy.trim() == 'true') ||
+        (has(object.spec.parameters.clientID) && size(object.spec.parameters.clientID.trim()) > 0)
+      message: "clientID is required when useAzureTokenProxy is true"
+    # cloudName must be a known value
+    - expression: >-
+        !has(object.spec.parameters.cloudName) ||
+        object.spec.parameters.cloudName.trim() in ['', 'AzurePublicCloud', 'AzureChinaCloud', 'AzureGermanCloud', 'AzureUSGovernmentCloud', 'AzureStackCloud']
+      message: "cloudName must be one of: AzurePublicCloud, AzureChinaCloud, AzureGermanCloud, AzureUSGovernmentCloud, AzureStackCloud"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: azure-secretproviderclass-validation
+spec:
+  policyName: azure-secretproviderclass-validation
+  validationActions:
+    - Deny

--- a/test/e2e/framework/deploy/deploy.go
+++ b/test/e2e/framework/deploy/deploy.go
@@ -41,6 +41,11 @@ var (
 	providerResources = []string{
 		"provider-azure-installer.yaml",
 	}
+
+	// clusterScopedResources are resources that don't need DS image updates
+	clusterScopedResources = []string{
+		"validatingadmissionpolicy.yaml",
+	}
 )
 
 // InstallManifest install driver and provider manifests from yaml files.
@@ -117,6 +122,12 @@ func InstallManifest(kubeconfigPath string, config *framework.Config) {
 
 		// Update DS with new configuration
 		err = exec.KubectlApply(kubeconfigPath, framework.NamespaceKubeSystem, []string{"-f", fmt.Sprintf("%s/updated-%s", providerResourceAbsolutePath, resource)})
+		Expect(err).To(BeNil())
+	}
+
+	// Install cluster-scoped resources (e.g. ValidatingAdmissionPolicy)
+	for _, resource := range clusterScopedResources {
+		err := exec.KubectlApply(kubeconfigPath, framework.NamespaceKubeSystem, []string{"-f", fmt.Sprintf("%s/%s", providerResourceAbsolutePath, resource)})
 		Expect(err).To(BeNil())
 	}
 }

--- a/test/e2e/validatingadmissionpolicy_test.go
+++ b/test/e2e/validatingadmissionpolicy_test.go
@@ -1,0 +1,173 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/namespace"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
+)
+
+var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func() {
+	var (
+		ns *corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		ns = namespace.CreateWithName(namespace.CreateInput{
+			Creator: kubeClient,
+			Name:    "vap-test",
+		})
+	})
+
+	AfterEach(func() {
+		Expect(kubeClient.Delete(context.TODO(), ns)).Should(Succeed())
+	})
+
+	validSPC := func(name string, params map[string]string) *v1alpha1.SecretProviderClass {
+		return &v1alpha1.SecretProviderClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns.Name,
+			},
+			Spec: v1alpha1.SecretProviderClassSpec{
+				Provider:   "azure",
+				Parameters: params,
+			},
+		}
+	}
+
+	baseParams := func() map[string]string {
+		return map[string]string{
+			types.KeyVaultNameParameter: "my-test-keyvault",
+			types.TenantIDParameter:     config.TenantID,
+			types.ClientIDParameter:     config.AzureClientID,
+		}
+	}
+
+	It("should accept a valid SecretProviderClass", func() {
+		spc := validSPC("valid-spc", baseParams())
+		Expect(kubeClient.Create(context.TODO(), spc)).Should(Succeed())
+	})
+
+	It("should reject SecretProviderClass with missing keyvaultName", func() {
+		params := baseParams()
+		delete(params, types.KeyVaultNameParameter)
+		spc := validSPC("missing-kvname", params)
+		err := kubeClient.Create(context.TODO(), spc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("keyvaultName"))
+	})
+
+	It("should reject SecretProviderClass with invalid keyvaultName (too short)", func() {
+		params := baseParams()
+		params[types.KeyVaultNameParameter] = "ab"
+		spc := validSPC("short-kvname", params)
+		err := kubeClient.Create(context.TODO(), spc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("keyvaultName"))
+	})
+
+	It("should reject SecretProviderClass with invalid keyvaultName (too long)", func() {
+		params := baseParams()
+		params[types.KeyVaultNameParameter] = "abcdefghijklmnopqrstuvwxy" // 25 chars
+		spc := validSPC("long-kvname", params)
+		err := kubeClient.Create(context.TODO(), spc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("keyvaultName"))
+	})
+
+	It("should reject SecretProviderClass with invalid keyvaultName (special chars)", func() {
+		params := baseParams()
+		params[types.KeyVaultNameParameter] = "my_vault.name"
+		spc := validSPC("invalid-chars-kvname", params)
+		err := kubeClient.Create(context.TODO(), spc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("keyvaultName"))
+	})
+
+	It("should reject SecretProviderClass with missing tenantId", func() {
+		params := baseParams()
+		delete(params, types.TenantIDParameter)
+		spc := validSPC("missing-tenantid", params)
+		err := kubeClient.Create(context.TODO(), spc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("tenantId"))
+	})
+
+	It("should reject SecretProviderClass with invalid usePodIdentity value", func() {
+		params := baseParams()
+		params[types.UsePodIdentityParameter] = "yes"
+		spc := validSPC("invalid-podidentity", params)
+		err := kubeClient.Create(context.TODO(), spc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("usePodIdentity"))
+	})
+
+	It("should reject SecretProviderClass with invalid useVMManagedIdentity value", func() {
+		params := baseParams()
+		params[types.UseVMManagedIdentityParameter] = "yes"
+		spc := validSPC("invalid-vmmi", params)
+		err := kubeClient.Create(context.TODO(), spc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("useVMManagedIdentity"))
+	})
+
+	It("should reject SecretProviderClass with multiple identity modes enabled", func() {
+		params := baseParams()
+		params[types.UsePodIdentityParameter] = "true"
+		params[types.UseVMManagedIdentityParameter] = "true"
+		spc := validSPC("multiple-identity", params)
+		err := kubeClient.Create(context.TODO(), spc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("only one identity mode"))
+	})
+
+	It("should reject SecretProviderClass with useAzureTokenProxy but no clientID", func() {
+		params := baseParams()
+		params[types.UseAzureTokenProxyParameter] = "true"
+		delete(params, types.ClientIDParameter)
+		spc := validSPC("tokenproxy-no-clientid", params)
+		err := kubeClient.Create(context.TODO(), spc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("clientID"))
+	})
+
+	It("should reject SecretProviderClass with invalid cloudName", func() {
+		params := baseParams()
+		params[types.CloudNameParameter] = "InvalidCloud"
+		spc := validSPC("invalid-cloudname", params)
+		err := kubeClient.Create(context.TODO(), spc)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cloudName"))
+	})
+
+	It("should accept SecretProviderClass with valid cloudName", func() {
+		params := baseParams()
+		params[types.CloudNameParameter] = "AzurePublicCloud"
+		spc := validSPC("valid-cloudname", params)
+		Expect(kubeClient.Create(context.TODO(), spc)).Should(Succeed())
+	})
+
+	It("should not affect non-azure provider SecretProviderClass", func() {
+		spc := &v1alpha1.SecretProviderClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "non-azure-spc",
+				Namespace: ns.Name,
+			},
+			Spec: v1alpha1.SecretProviderClassSpec{
+				Provider:   "vault",
+				Parameters: map[string]string{},
+			},
+		}
+		Expect(kubeClient.Create(context.TODO(), spc)).Should(Succeed())
+	})
+})

--- a/test/e2e/validatingadmissionpolicy_test.go
+++ b/test/e2e/validatingadmissionpolicy_test.go
@@ -64,7 +64,7 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 		spc := validSPC("missing-kvname", params)
 		err := kubeClient.Create(context.TODO(), spc)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("keyvaultName"))
+		Expect(err.Error()).To(ContainSubstring("keyvaultName is required and must be 3-24 alphanumeric/hyphen characters"))
 	})
 
 	It("should reject SecretProviderClass with invalid keyvaultName (too short)", func() {
@@ -73,7 +73,7 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 		spc := validSPC("short-kvname", params)
 		err := kubeClient.Create(context.TODO(), spc)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("keyvaultName"))
+		Expect(err.Error()).To(ContainSubstring("keyvaultName is required and must be 3-24 alphanumeric/hyphen characters"))
 	})
 
 	It("should reject SecretProviderClass with invalid keyvaultName (too long)", func() {
@@ -82,7 +82,7 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 		spc := validSPC("long-kvname", params)
 		err := kubeClient.Create(context.TODO(), spc)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("keyvaultName"))
+		Expect(err.Error()).To(ContainSubstring("keyvaultName is required and must be 3-24 alphanumeric/hyphen characters"))
 	})
 
 	It("should reject SecretProviderClass with invalid keyvaultName (special chars)", func() {
@@ -91,7 +91,7 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 		spc := validSPC("invalid-chars-kvname", params)
 		err := kubeClient.Create(context.TODO(), spc)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("keyvaultName"))
+		Expect(err.Error()).To(ContainSubstring("keyvaultName is required and must be 3-24 alphanumeric/hyphen characters"))
 	})
 
 	It("should reject SecretProviderClass with missing tenantId", func() {
@@ -100,7 +100,7 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 		spc := validSPC("missing-tenantid", params)
 		err := kubeClient.Create(context.TODO(), spc)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("tenantId"))
+		Expect(err.Error()).To(ContainSubstring("tenantId or tenantID is required"))
 	})
 
 	It("should reject SecretProviderClass with invalid usePodIdentity value", func() {
@@ -109,7 +109,7 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 		spc := validSPC("invalid-podidentity", params)
 		err := kubeClient.Create(context.TODO(), spc)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("usePodIdentity"))
+		Expect(err.Error()).To(ContainSubstring("usePodIdentity must be 'true' or 'false'"))
 	})
 
 	It("should reject SecretProviderClass with invalid useVMManagedIdentity value", func() {
@@ -118,7 +118,7 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 		spc := validSPC("invalid-vmmi", params)
 		err := kubeClient.Create(context.TODO(), spc)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("useVMManagedIdentity"))
+		Expect(err.Error()).To(ContainSubstring("useVMManagedIdentity must be 'true' or 'false'"))
 	})
 
 	It("should reject SecretProviderClass with multiple identity modes enabled", func() {
@@ -128,7 +128,7 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 		spc := validSPC("multiple-identity", params)
 		err := kubeClient.Create(context.TODO(), spc)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("only one identity mode"))
+		Expect(err.Error()).To(ContainSubstring("only one identity mode can be enabled at a time: usePodIdentity, useVMManagedIdentity, or useAzureTokenProxy"))
 	})
 
 	It("should reject SecretProviderClass with useAzureTokenProxy but no clientID", func() {
@@ -138,7 +138,7 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 		spc := validSPC("tokenproxy-no-clientid", params)
 		err := kubeClient.Create(context.TODO(), spc)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("clientID"))
+		Expect(err.Error()).To(ContainSubstring("clientID is required when useAzureTokenProxy is true"))
 	})
 
 	It("should reject SecretProviderClass with invalid cloudName", func() {
@@ -147,7 +147,7 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 		spc := validSPC("invalid-cloudname", params)
 		err := kubeClient.Create(context.TODO(), spc)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("cloudName"))
+		Expect(err.Error()).To(ContainSubstring("cloudName must be one of: AzurePublicCloud, AzureChinaCloud, AzureGermanCloud, AzureUSGovernmentCloud, AzureStackCloud"))
 	})
 
 	It("should accept SecretProviderClass with valid cloudName", func() {

--- a/test/e2e/validatingadmissionpolicy_test.go
+++ b/test/e2e/validatingadmissionpolicy_test.go
@@ -22,7 +22,7 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 	)
 
 	BeforeEach(func() {
-		ns = namespace.CreateWithName(namespace.CreateInput{
+		ns = namespace.Create(namespace.CreateInput{
 			Creator: kubeClient,
 			Name:    "vap-test",
 		})
@@ -48,8 +48,8 @@ var _ = Describe("ValidatingAdmissionPolicy for Azure SecretProviderClass", func
 	baseParams := func() map[string]string {
 		return map[string]string{
 			types.KeyVaultNameParameter: "my-test-keyvault",
-			types.TenantIDParameter:     config.TenantID,
-			types.ClientIDParameter:     config.AzureClientID,
+			types.TenantIDParameter:     "00000000-0000-0000-0000-000000000000",
+			types.ClientIDParameter:     "00000000-0000-0000-0000-000000000001",
 		}
 	}
 


### PR DESCRIPTION
Add a native Kubernetes ValidatingAdmissionPolicy (CEL-based) to validate SecretProviderClass parameters at apply time for the Azure provider, shifting error detection from mount time to resource creation.

Validations enforced:
- keyvaultName required, 3-24 chars, alphanumeric/hyphens only
- tenantId or tenantID required and non-empty
- usePodIdentity/useVMManagedIdentity/useAzureTokenProxy must be valid boolean strings
- at most one identity mode flag enabled (mutual exclusivity)
- clientID required when useAzureTokenProxy is true
- cloudName must be a known Azure cloud name

The policy uses `matchConditions` to only apply to `SecretProviderClasses` with `spec.provider == "azure"`, leaving other providers unaffected.