### PR TITLE
test(e2e): assert no provider pod restarts after suite + soak

### DIFF
--- a/.pipelines/templates/e2e-test.yaml
+++ b/.pipelines/templates/e2e-test.yaml
@@ -70,6 +70,8 @@ steps:
         CI_KIND_CLUSTER: ${{ parameters.ciKindCluster }}
       ${{ if parameters.isArcTest }}:
         IS_ARC_TEST: ${{ parameters.isArcTest }}
+      ${{ if parameters.testReleasedVersion }}:
+        IS_RELEASED_VERSION_TEST: ${{ parameters.testReleasedVersion }}
       # If the image is a released versions (i.e <= v1.3), it still doesn't support the
       # split cert/key feature, so we need to skip tests for those versions.
       # Identity binding is also only supported in newer versions.

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -37,17 +38,50 @@ var (
 	coreNamespaces = []string{
 		framework.NamespaceKubeSystem,
 	}
+	// anySpecFailed is set to true by an AfterEach hook whenever a spec
+	// fails. The post-suite stability check uses this to avoid burying
+	// the real failure under cascading assertions.
+	anySpecFailed bool
 )
 
 const (
 	// podStartTimeout is how long to wait for the pod to be started.
 	podStartTimeout = 5 * time.Minute
+
+	// defaultPostSuiteSoak is the soak window applied after all specs
+	// complete before re-asserting that driver and provider pods are
+	// still healthy with zero container restarts. The window covers the
+	// default Windows livenessProbe cadence (failureThreshold 3 x
+	// periodSeconds 30 = ~90s) plus headroom, so a probe regression like
+	// issue #2029 surfaces here even if it does not fire during the
+	// regular suite.
+	defaultPostSuiteSoak = 2 * time.Minute
+
+	// postSuiteSoakEnv overrides defaultPostSuiteSoak. Accepts any
+	// time.ParseDuration value. Set to "0" to skip the soak entirely
+	// (useful for local iteration).
+	postSuiteSoakEnv = "E2E_POST_SUITE_SOAK"
 )
+
+// providerAndDriverAppLabels is the set of `app` label values used by the
+// driver and Azure provider DaemonSets. Kept as a package var so the
+// BeforeSuite readiness wait and the AfterSuite stability check stay in
+// sync.
+var providerAndDriverAppLabels = []string{
+	"secrets-store-csi-driver",
+	"csi-secrets-store-provider-azure",
+}
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "sscdproviderazure")
 }
+
+var _ = AfterEach(func() {
+	if CurrentSpecReport().Failed() {
+		anySpecFailed = true
+	}
+})
 
 var _ = BeforeSuite(func(ctx context.Context) {
 	By("Parsing test configuration")
@@ -90,7 +124,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 
 	// Ensure driver and provider pods are running and ready before starting tests
 	By("Waiting for driver and provider pods to be running and ready before starting tests.")
-	driverAndProviderLabels, err := labels.NewRequirement("app", selection.In, []string{"secrets-store-csi-driver", "csi-secrets-store-provider-azure"})
+	driverAndProviderLabels, err := labels.NewRequirement("app", selection.In, providerAndDriverAppLabels)
 	Expect(err).To(BeNil())
 
 	podSelector := labels.NewSelector().Add(*driverAndProviderLabels)
@@ -100,7 +134,11 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	}
 })
 
-var _ = AfterSuite(func() {
+var _ = AfterSuite(func(ctx context.Context) {
+	// Run uninstall LAST and dumpLogs SECOND-TO-LAST so they execute
+	// even if the post-suite stability check fails — otherwise a
+	// regression like issue #2029 would tear down the cluster before
+	// we capture the evidence needed to debug it.
 	defer func() {
 		// uninstall if it's not Soak Test, not backward compatibility test and if cluster is already upgraded or it's not cluster upgrade test
 		if !config.IsSoakTest && !config.IsArcTest && !config.IsBackwardCompatibilityTest && (!config.IsUpgradeTest || config.IsClusterUpgraded) {
@@ -110,9 +148,72 @@ var _ = AfterSuite(func() {
 			}
 		}
 	}()
+	defer dumpLogs()
 
-	dumpLogs()
+	runPostSuiteStabilityCheck(ctx)
 })
+
+// runPostSuiteStabilityCheck asserts that the driver and provider
+// DaemonSets remained healthy across the suite and stay healthy through
+// a short soak window. It is the safety net for liveness/readiness
+// regressions (see issue #2029, where the provider's healthz dial was
+// broken on Windows and crash-looped the pod every ~90s).
+//
+// It deliberately skips:
+//   - runs where a spec already failed (the real failure is upstream,
+//     and we do not want to bury it with cascading assertions);
+//   - test modes that legitimately churn provider pods (soak, cluster
+//     upgrade) or do not install the provider in the usual shape (arc);
+//   - runs against a previously-published chart (IsReleasedVersionTest),
+//     since we do not want a known bug shipped in v1.x to permanently
+//     red-light this safety net on every PR. Regressions on the
+//     candidate change are still caught by the "Run e2e test with New
+//     Version" invocation, which does not set IS_RELEASED_VERSION_TEST.
+func runPostSuiteStabilityCheck(ctx context.Context) {
+	if anySpecFailed {
+		By("Skipping post-suite stability check: at least one spec already failed")
+		return
+	}
+	if config.IsSoakTest || config.IsArcTest || config.IsReleasedVersionTest || config.IsUpgradeTest {
+		By("Skipping post-suite stability check: not applicable for this test mode")
+		return
+	}
+
+	soak := defaultPostSuiteSoak
+	if v, ok := os.LookupEnv(postSuiteSoakEnv); ok {
+		parsed, err := time.ParseDuration(v)
+		Expect(err).To(BeNil(), "invalid %s=%q", postSuiteSoakEnv, v)
+		soak = parsed
+	}
+
+	By("Verifying driver and provider pods have zero container restarts after the suite")
+	pod.AssertNoRestarts(pod.AssertNoRestartsInput{
+		Lister:         kubeClient,
+		KubeconfigPath: kubeconfigPath,
+		Namespace:      framework.NamespaceKubeSystem,
+		AppLabels:      providerAndDriverAppLabels,
+	})
+
+	if soak <= 0 {
+		return
+	}
+
+	By(fmt.Sprintf("Soaking for %s to catch slow-burn liveness/healthz regressions", soak))
+	select {
+	case <-time.After(soak):
+	case <-ctx.Done():
+		return
+	}
+
+	By("Verifying driver and provider pods are still Ready with zero container restarts after soak")
+	pod.AssertNoRestarts(pod.AssertNoRestartsInput{
+		Lister:         kubeClient,
+		KubeconfigPath: kubeconfigPath,
+		Namespace:      framework.NamespaceKubeSystem,
+		AppLabels:      providerAndDriverAppLabels,
+		VerifyReady:    true,
+	})
+}
 
 func initScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()

--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -33,8 +33,14 @@ type Config struct {
 	HelmChartDir                      string `envconfig:"HELM_CHART_DIR" default:"manifest_staging/charts/csi-secrets-store-provider-azure"`
 	IsClusterUpgraded                 bool   `envconfig:"IS_CLUSTER_UPGRADED"`
 	IsBackwardCompatibilityTest       bool   `envconfig:"IS_BACKWARD_COMPATIBILITY_TEST"`
-	AzureEnvironmentFilePath          string `envconfig:"AZURE_ENVIRONMENT_FILEPATH"`
-	IsArcTest                         bool   `envconfig:"IS_ARC_TEST" default:"false"`
+	// IsReleasedVersionTest is true when the suite is running against a
+	// previously-published helm chart (i.e. testReleasedVersion=true in
+	// the ADO pipeline). The post-suite stability check uses this to
+	// avoid failing CI on liveness/healthz bugs already shipped in a
+	// released version.
+	IsReleasedVersionTest    bool   `envconfig:"IS_RELEASED_VERSION_TEST"`
+	AzureEnvironmentFilePath string `envconfig:"AZURE_ENVIRONMENT_FILEPATH"`
+	IsArcTest                bool   `envconfig:"IS_ARC_TEST" default:"false"`
 }
 
 func (c *Config) DeepCopy() *Config {
@@ -60,6 +66,7 @@ func (c *Config) DeepCopy() *Config {
 	copy.HelmChartDir = c.HelmChartDir
 	copy.IsClusterUpgraded = c.IsClusterUpgraded
 	copy.IsBackwardCompatibilityTest = c.IsBackwardCompatibilityTest
+	copy.IsReleasedVersionTest = c.IsReleasedVersionTest
 	copy.AzureEnvironmentFilePath = c.AzureEnvironmentFilePath
 	copy.IsHelmTest = c.IsHelmTest
 	copy.IsArcTest = c.IsArcTest

--- a/test/e2e/framework/exec/kubectl.go
+++ b/test/e2e/framework/exec/kubectl.go
@@ -65,6 +65,24 @@ func KubectlLogs(kubeconfigPath, podName, containerName, namespace string) (stri
 	return kubectl(args)
 }
 
+// KubectlLogsPrevious executes "kubectl logs --previous" to fetch logs from
+// the prior container instance. Useful for debugging crash-looping containers.
+func KubectlLogsPrevious(kubeconfigPath, podName, containerName, namespace string) (string, error) {
+	args := []string{
+		"logs",
+		"--previous",
+		fmt.Sprintf("--kubeconfig=%s", kubeconfigPath),
+		fmt.Sprintf("--namespace=%s", namespace),
+		podName,
+	}
+
+	if containerName != "" {
+		args = append(args, fmt.Sprintf("-c=%s", containerName))
+	}
+
+	return kubectl(args)
+}
+
 // KubectlDescribe executes "kubectl describe" given a list of arguments.
 func KubectlDescribe(kubeconfigPath, podName, namespace string) (string, error) {
 	args := []string{

--- a/test/e2e/framework/pod/pod.go
+++ b/test/e2e/framework/pod/pod.go
@@ -6,6 +6,7 @@ package pod
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo/v2"
@@ -15,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework"
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/exec"
 )
 
 // ListInput is the input of List.
@@ -195,4 +197,93 @@ func WaitFor(input WaitForInput) {
 		}
 		return false
 	}, framework.Timeout, framework.Polling).Should(BeTrue())
+}
+
+// AssertNoRestartsInput is the input for AssertNoRestarts.
+type AssertNoRestartsInput struct {
+	Lister         framework.Lister
+	KubeconfigPath string
+	Namespace      string
+	// AppLabels is the set of "app" label values to match. Pods matching any
+	// of these values are checked. Logical OR.
+	AppLabels []string
+	// VerifyReady additionally asserts that every matched pod has the Ready
+	// condition set to True.
+	VerifyReady bool
+}
+
+// AssertNoRestarts fails the current spec if any container in any pod
+// matching one of input.AppLabels has restartCount > 0. When VerifyReady
+// is true, also fails if any matched pod is not Ready.
+//
+// On failure, dumps `kubectl describe pod` for offending pods and
+// `kubectl logs --previous` for offending containers so the CI artifacts
+// contain enough state to debug the regression (e.g. liveness flap, OOM,
+// startup panic) without needing to reproduce it.
+func AssertNoRestarts(input AssertNoRestartsInput) {
+	Expect(input.Lister).NotTo(BeNil(), "input.Lister is required for Pod.AssertNoRestarts")
+	Expect(input.KubeconfigPath).NotTo(BeEmpty(), "input.KubeconfigPath is required for Pod.AssertNoRestarts")
+	Expect(input.Namespace).NotTo(BeEmpty(), "input.Namespace is required for Pod.AssertNoRestarts")
+	Expect(input.AppLabels).NotTo(BeEmpty(), "input.AppLabels is required for Pod.AssertNoRestarts")
+
+	var allPods []corev1.Pod
+	for _, app := range input.AppLabels {
+		podList := List(ListInput{
+			Lister:    input.Lister,
+			Namespace: input.Namespace,
+			Labels:    map[string]string{"app": app},
+		})
+		allPods = append(allPods, podList.Items...)
+	}
+	Expect(allPods).NotTo(BeEmpty(),
+		"expected at least one pod in namespace %q matching app labels %v", input.Namespace, input.AppLabels)
+
+	var problems []string
+	offenders := map[string]bool{}
+	for _, p := range allPods {
+		for _, cs := range p.Status.ContainerStatuses {
+			if cs.RestartCount > 0 {
+				problems = append(problems,
+					fmt.Sprintf("pod %s/%s container %q restarted %d time(s)", p.Namespace, p.Name, cs.Name, cs.RestartCount))
+				offenders[p.Name] = true
+			}
+		}
+		if input.VerifyReady {
+			ready := false
+			for _, c := range p.Status.Conditions {
+				if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+					ready = true
+					break
+				}
+			}
+			if !ready {
+				problems = append(problems,
+					fmt.Sprintf("pod %s/%s is not Ready (phase=%s)", p.Namespace, p.Name, p.Status.Phase))
+				offenders[p.Name] = true
+			}
+		}
+	}
+
+	if len(problems) == 0 {
+		return
+	}
+
+	for _, p := range allPods {
+		if !offenders[p.Name] {
+			continue
+		}
+		if describe, err := exec.KubectlDescribe(input.KubeconfigPath, p.Name, p.Namespace); err == nil {
+			By(fmt.Sprintf("kubectl describe pod %s/%s:\n%s", p.Namespace, p.Name, describe))
+		}
+		for _, cs := range p.Status.ContainerStatuses {
+			if cs.RestartCount == 0 {
+				continue
+			}
+			if prev, err := exec.KubectlLogsPrevious(input.KubeconfigPath, p.Name, cs.Name, p.Namespace); err == nil {
+				By(fmt.Sprintf("Previous container logs for pod %s/%s container %q:\n%s", p.Namespace, p.Name, cs.Name, prev))
+			}
+		}
+	}
+
+	Fail("post-suite stability check failed:\n  - " + strings.Join(problems, "\n  - "))
 }


### PR DESCRIPTION
Add a post-suite stability check that runs after every spec completes and asserts that no container in any
secrets-store-csi-driver or csi-secrets-store-provider-azure pod has restarted. After an immediate check, soak for 2m (overridable via E2E_POST_SUITE_SOAK) and re-assert restarts and Ready, so liveness-probe regressions like #2029 surface in CI even when the first failure only fires ~90s into container life.

On failure, kubectl describe and previous-container logs are captured for offending pods so the run artifacts are debuggable.

Skip the check when a spec already failed (to avoid burying the real failure) and when running soak / arc / upgrade / backward- compatibility tests (where provider pods legitimately churn or are not installed).