### PR TITLE
ci: support workload identity federation in az login

### DIFF
--- a/.pipelines/e2e-job-azure.yaml
+++ b/.pipelines/e2e-job-azure.yaml
@@ -16,12 +16,18 @@ pool:
   demands:
   - ImageOverride -equals 1es-azlinux-3-amd64-custom-disk
 
+parameters:
+  - name: serviceConnection
+    type: string
+    default: 'Upstream-CI-Service-Connection'
+
 jobs:
   - template: templates/e2e-test-azure.yaml
     parameters:
       osTypes:
       - "linux"
       - "windows"
+      serviceConnection: ${{ parameters.serviceConnection }}
   # TODO: re-enable this job after implementing automated ext release process
   # using https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/1382 for tracking
   # this will ensure any changes to provider works on arc extension too.

--- a/.pipelines/nightly.yaml
+++ b/.pipelines/nightly.yaml
@@ -13,10 +13,17 @@ pool:
   demands:
   - ImageOverride -equals 1es-azlinux-3-amd64-custom-disk
 
+parameters:
+  - name: serviceConnection
+    type: string
+    default: 'Upstream-CI-Service-Connection'
+
 jobs:
   # to get image scan results on nightly runs
   - template: templates/unit-test.yaml
   - template: templates/e2e-test-kind.yaml
+    parameters:
+      serviceConnection: ${{ parameters.serviceConnection }}
   - template: templates/load-test.yaml
   - template: templates/e2e-test-azure.yaml
     parameters:
@@ -24,14 +31,19 @@ jobs:
       - "linux"
       - "windows"
       testClusterUpgrade: true
+      serviceConnection: ${{ parameters.serviceConnection }}
   - template: templates/e2e-test-azure.yaml
     parameters:
       osTypes:
       - "linux"
       testWithGPU: true
+      serviceConnection: ${{ parameters.serviceConnection }}
   - template: templates/soak-test.yaml
     parameters:
       clusterConfigs:
       - "csi-secrets-store-soak-linux-aks"
       - "csi-secrets-store-soak-win-aks"
+      serviceConnection: ${{ parameters.serviceConnection }}
   - template: templates/arc/e2e-test-kind.yaml
+    parameters:
+      serviceConnection: ${{ parameters.serviceConnection }}

--- a/.pipelines/templates/arc/e2e-test-kind.yaml
+++ b/.pipelines/templates/arc/e2e-test-kind.yaml
@@ -1,3 +1,12 @@
+parameters:
+  - name: serviceConnection
+    type: string
+    # Default to the staging WIF service connection so the template works
+    # both as an entry pipeline (ADO-registered) and when called from
+    # nightly.yaml. Pass an empty string explicitly to force the
+    # managed-identity branch.
+    default: 'Upstream-CI-Service-Connection'
+
 jobs:
   - job: e2e_arc_kind
     pool:
@@ -10,6 +19,8 @@ jobs:
     - group: csi-secrets-store-e2e-kind
     steps:
     - template: ../az-login.yaml
+      parameters:
+        serviceConnection: ${{ parameters.serviceConnection }}
     - template: setup.yaml
     - script: |
         make install-helm install-kubectl setup-kind
@@ -37,3 +48,5 @@ jobs:
         ciKindCluster: true
         isArcTest: true
     - template: ../teardown.yaml
+      parameters:
+        serviceConnection: ${{ parameters.serviceConnection }}

--- a/.pipelines/templates/az-login.yaml
+++ b/.pipelines/templates/az-login.yaml
@@ -1,8 +1,48 @@
+# Logs in to Azure for use by subsequent az / kubectl / helm commands.
+#
+# Prefers Workload Identity Federation (WIF) when a `serviceConnection`
+# name is supplied. Falls back to `az login --identity` for pools that
+# still have a Managed Identity assigned. Pipelines whose pool MI was
+# removed must pass a WIF-capable service connection; without one the
+# MI path will fail.
+parameters:
+  - name: serviceConnection
+    type: string
+    default: ''
+
 steps:
-  - script:
-      az --version || sudo tdnf install -y azure-cli
-  - script: |
-      az login -i > /dev/null
-      az account set -s=$(SUBSCRIPTION_ID)
-    displayName: "az login"
-    condition: succeeded()
+  - script: az --version || sudo tdnf install -y azure-cli
+    displayName: "Install azure-cli (if missing)"
+
+  - ${{ if ne(parameters.serviceConnection, '') }}:
+      - task: AzureCLI@2
+        displayName: "Extract WIF identity"
+        inputs:
+          azureSubscription: ${{ parameters.serviceConnection }}
+          addSpnToEnvironment: true
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -u
+            echo "servicePrincipalId set: ${servicePrincipalId:+yes} (len=${#servicePrincipalId})"
+            echo "tenantId set:           ${tenantId:+yes} (len=${#tenantId})"
+            echo "idToken set:            ${idToken:+yes} (len=${#idToken})"
+            echo "##vso[task.setvariable variable=ARM_CLIENT_ID]$servicePrincipalId"
+            echo "##vso[task.setvariable variable=ARM_ID_TOKEN;issecret=true]$idToken"
+            echo "##vso[task.setvariable variable=ARM_TENANT_ID]$tenantId"
+
+      - bash: |
+          set -eu
+          az login \
+            --service-principal \
+            -u "$(ARM_CLIENT_ID)" \
+            --tenant "$(ARM_TENANT_ID)" \
+            --allow-no-subscriptions \
+            --federated-token "$(ARM_ID_TOKEN)" > /dev/null
+          az account set -s=$(SUBSCRIPTION_ID)
+        displayName: "az login (WIF)"
+  - ${{ else }}:
+      - script: |
+          az login -i > /dev/null
+          az account set -s=$(SUBSCRIPTION_ID)
+        displayName: "az login (managed identity)"

--- a/.pipelines/templates/build-images.yaml
+++ b/.pipelines/templates/build-images.yaml
@@ -5,9 +5,14 @@ parameters:
   - name: ciKindCluster
     type: boolean
     default: false
+  - name: serviceConnection
+    type: string
+    default: ''
 
 steps:
   - template: az-login.yaml
+    parameters:
+      serviceConnection: ${{ parameters.serviceConnection }}
   - script: |
       if [[ ${{ parameters.ciKindCluster }} == True ]]; then
         export CI_KIND_CLUSTER=true

--- a/.pipelines/templates/e2e-test-azure.yaml
+++ b/.pipelines/templates/e2e-test-azure.yaml
@@ -7,6 +7,9 @@ parameters:
   - name: testWithGPU
     type: boolean
     default: false
+  - name: serviceConnection
+    type: string
+    default: ''
 
 jobs:
   - ${{ each osType in parameters.osTypes }}:
@@ -42,6 +45,8 @@ jobs:
         displayName: 'Install kubectl'
 
       - template: build-images.yaml
+        parameters:
+          serviceConnection: ${{ parameters.serviceConnection }}
 
       - template: aks-setup.yaml
         parameters:
@@ -103,6 +108,8 @@ jobs:
 
       - template: cleanup-role-assignments.yaml
       - template: teardown.yaml
+        parameters:
+          serviceConnection: ${{ parameters.serviceConnection }}
       - template: cleanup-images.yaml
         parameters:
           imageVersion: $(IMAGE_VERSION)

--- a/.pipelines/templates/e2e-test-kind.yaml
+++ b/.pipelines/templates/e2e-test-kind.yaml
@@ -1,3 +1,12 @@
+parameters:
+  - name: serviceConnection
+    type: string
+    # Default to the staging WIF service connection so the template works
+    # both as an entry pipeline (ADO-registered) and when called from
+    # nightly.yaml. Pass an empty string explicitly to force the
+    # managed-identity branch.
+    default: 'Upstream-CI-Service-Connection'
+
 jobs:
   - job:
     timeoutInMinutes: 20
@@ -39,6 +48,8 @@ jobs:
       # logging in to download the sa.pub and sa.key used for creating the kind cluster
       # with OIDC issuer enabled
       - template: az-login.yaml
+        parameters:
+          serviceConnection: ${{ parameters.serviceConnection }}
       - script: |
           export REGISTRY="e2e"
           export IMAGE_VERSION=e2e-$(git rev-parse --short HEAD)

--- a/.pipelines/templates/soak-test.yaml
+++ b/.pipelines/templates/soak-test.yaml
@@ -1,6 +1,9 @@
 parameters:
   - name: clusterConfigs
     type: object
+  - name: serviceConnection
+    type: string
+    default: ''
 
 jobs:
   - ${{ each clusterConfig in parameters.clusterConfigs }}:
@@ -26,11 +29,12 @@ jobs:
             sudo mv kubectl /usr/local/bin/
           displayName: "Install kubectl"
 
+        - template: az-login.yaml
+          parameters:
+            serviceConnection: ${{ parameters.serviceConnection }}
+
         - script: |
             # Download kubeconfig for soak cluster
-            az login -i > /dev/null
-            az account set -s=$(SUBSCRIPTION_ID)
-
             az aks get-credentials \
               --resource-group $(CLUSTER_RESOURCE_GROUP) \
               --name $(CLUSTER_CONFIG)

--- a/.pipelines/templates/teardown.yaml
+++ b/.pipelines/templates/teardown.yaml
@@ -1,6 +1,13 @@
+parameters:
+  - name: serviceConnection
+    type: string
+    default: ''
+
 steps:
+  - template: az-login.yaml
+    parameters:
+      serviceConnection: ${{ parameters.serviceConnection }}
   - script: |
-      az login -i > /dev/null
       echo "deleting '${AZURE_CLUSTER_NAME}' resource group"
       az group delete -n ${AZURE_CLUSTER_NAME} --subscription $(SUBSCRIPTION_ID) --yes --no-wait
     displayName: "Teardown cluster"

--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -35,9 +35,6 @@ type Config struct {
 	IsBackwardCompatibilityTest       bool   `envconfig:"IS_BACKWARD_COMPATIBILITY_TEST"`
 	AzureEnvironmentFilePath          string `envconfig:"AZURE_ENVIRONMENT_FILEPATH"`
 	IsArcTest                         bool   `envconfig:"IS_ARC_TEST" default:"false"`
-
-	// KeyvaultClientID is the client ID of the service principal used to access the keyvault
-	KeyvaultClientID string `envconfig:"KEYVAULT_CLIENT_ID" default:"878afdc6-3fc3-4c3e-be5c-f28377892326"`
 }
 
 func (c *Config) DeepCopy() *Config {
@@ -66,7 +63,6 @@ func (c *Config) DeepCopy() *Config {
 	copy.AzureEnvironmentFilePath = c.AzureEnvironmentFilePath
 	copy.IsHelmTest = c.IsHelmTest
 	copy.IsArcTest = c.IsArcTest
-	copy.KeyvaultClientID = c.KeyvaultClientID
 
 	return copy
 }

--- a/test/e2e/framework/keyvault/keyvault.go
+++ b/test/e2e/framework/keyvault/keyvault.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -32,15 +30,10 @@ type client struct {
 }
 
 func NewClient(config *framework.Config) Client {
-	opts := &azidentity.ManagedIdentityCredentialOptions{
-		ClientOptions: azcore.ClientOptions{
-			Cloud: cloud.Configuration{
-				ActiveDirectoryAuthorityHost: azure.PublicCloud.ActiveDirectoryEndpoint,
-			},
-		},
-		ID: azidentity.ClientID(config.KeyvaultClientID),
-	}
-	cred, err := azidentity.NewManagedIdentityCredential(opts)
+	// Use Azure CLI credential so the test reuses the `az login` (WIF) session
+	// performed by the pipeline. This avoids depending on a pool-level managed
+	// identity, which is no longer available on the CI agents.
+	cred, err := azidentity.NewAzureCLICredential(nil)
 	Expect(err).To(BeNil())
 
 	c, err := azsecrets.NewClient(getVaultURL(config.KeyvaultName), cred, nil)


### PR DESCRIPTION
Pool managed identity was removed, so `az login -i` fails. Add a WIF path via AzureCLI@2 when an `azureSubscription` service connection is provided, with the MI script as fallback. Plumb the parameter through every template that performs an az login.