### PR TITLE
feat: Support objectNotAfter timestamp-based object selection

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -341,7 +341,7 @@ func (p *provider) GetSecretsStoreObjectContent(ctx context.Context, attrib, sec
 }
 
 func (p *provider) resolveObjectVersions(ctx context.Context, kvClient KeyVault, kvObject types.KeyVaultObject) (versions []types.KeyVaultObject, err error) {
-	if kvObject.IsSyncingSingleVersion() {
+	if kvObject.IsSyncingSingleVersion() && kvObject.ObjectNotAfter.IsZero() {
 		// version history less than or equal to 1 means only sync the latest and
 		// don't add anything to the file name
 		return []types.KeyVaultObject{kvObject}, nil
@@ -352,7 +352,30 @@ func (p *provider) resolveObjectVersions(ctx context.Context, kvClient KeyVault,
 		return nil, err
 	}
 
+	if kvObject.IsSyncingSingleVersion() && !kvObject.ObjectNotAfter.IsZero() {
+		version, err := getLatestVersionNotAfter(kvObjectVersions, kvObject.ObjectNotAfter)
+		if err != nil {
+			return nil, err
+		}
+
+		return []types.KeyVaultObject{kvObject.WithVersion(version.Version)}, nil
+	}
+
 	return getLatestNKeyVaultObjects(kvObject, kvObjectVersions), nil
+}
+
+func getLatestVersionNotAfter(kvObjectVersions types.KeyVaultObjectVersionList, objectNotAfter time.Time) (types.KeyVaultObjectVersion, error) {
+	sort.Sort(kvObjectVersions)
+
+	for _, objectVersion := range kvObjectVersions {
+		if objectVersion.Created.After(objectNotAfter) {
+			continue
+		}
+
+		return objectVersion, nil
+	}
+
+	return types.KeyVaultObjectVersion{}, errors.Errorf("no versions found before objectNotAfter: %s", objectNotAfter)
 }
 
 /*
@@ -373,6 +396,10 @@ func getLatestNKeyVaultObjects(kvObject types.KeyVaultObject, kvObjectVersions t
 	foundFirst := kvObject.ObjectVersion == "" || kvObject.ObjectVersion == "latest"
 
 	for _, objectVersion := range kvObjectVersions {
+		if !kvObject.ObjectNotAfter.IsZero() && objectVersion.Created.After(kvObject.ObjectNotAfter) {
+			continue
+		}
+
 		foundFirst = foundFirst || objectVersion.Version == kvObject.ObjectVersion
 
 		if foundFirst {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/klog/v2"
 
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/metrics"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/mock_keyvault"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 )
@@ -586,6 +587,55 @@ func TestGetLatestNKeyVaultObjects(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "ignores versions created after objectNotAfter",
+			kvObject: types.KeyVaultObject{
+				ObjectName:           "secret1",
+				ObjectVersionHistory: 3,
+				ObjectNotAfter:       time.Date(2026, time.June, 5, 19, 41, 0, 0, time.UTC),
+			},
+			versions: types.KeyVaultObjectVersionList{
+				types.KeyVaultObjectVersion{
+					Version: "a",
+					Created: time.Date(2026, 6, 5, 19, 42, 0, 0, time.UTC),
+				},
+				types.KeyVaultObjectVersion{
+					Version: "b",
+					Created: time.Date(2026, 6, 5, 19, 41, 0, 0, time.UTC),
+				},
+				types.KeyVaultObjectVersion{
+					Version: "c",
+					Created: time.Date(2026, 6, 5, 19, 40, 0, 0, time.UTC),
+				},
+				types.KeyVaultObjectVersion{
+					Version: "d",
+					Created: time.Date(2026, 6, 5, 19, 39, 0, 0, time.UTC),
+				},
+			},
+			expectedObjects: []types.KeyVaultObject{
+				{
+					ObjectName:           "secret1",
+					ObjectAlias:          filepath.Join("secret1", "0"),
+					ObjectVersion:        "b",
+					ObjectVersionHistory: 3,
+					ObjectNotAfter:       time.Date(2026, time.June, 5, 19, 41, 0, 0, time.UTC),
+				},
+				{
+					ObjectName:           "secret1",
+					ObjectAlias:          filepath.Join("secret1", "1"),
+					ObjectVersion:        "c",
+					ObjectVersionHistory: 3,
+					ObjectNotAfter:       time.Date(2026, time.June, 5, 19, 41, 0, 0, time.UTC),
+				},
+				{
+					ObjectName:           "secret1",
+					ObjectAlias:          filepath.Join("secret1", "2"),
+					ObjectVersion:        "d",
+					ObjectVersionHistory: 3,
+					ObjectNotAfter:       time.Date(2026, time.June, 5, 19, 41, 0, 0, time.UTC),
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -599,6 +649,52 @@ func TestGetLatestNKeyVaultObjects(t *testing.T) {
 	}
 }
 
+func TestResolveObjectVersionsWithObjectNotAfter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockKvClient := mock_keyvault.NewMockKeyVault(ctrl)
+	ctx := context.Background()
+
+	kvObject := types.KeyVaultObject{
+		ObjectName:           "secret1",
+		ObjectType:           types.VaultObjectTypeSecret,
+		ObjectVersionHistory: 1,
+		ObjectNotAfter:       time.Date(2026, time.June, 5, 19, 41, 0, 0, time.UTC),
+	}
+
+	mockKvClient.EXPECT().GetSecretVersions(ctx, "secret1").Return([]types.KeyVaultObjectVersion{
+		{
+			Version: "too-new",
+			Created: time.Date(2026, 6, 5, 19, 42, 0, 0, time.UTC),
+		},
+		{
+			Version: "eligible",
+			Created: time.Date(2026, 6, 5, 19, 41, 0, 0, time.UTC),
+		},
+	}, nil)
+
+	p := &provider{reporter: metrics.NewStatsReporter()}
+	resolved, err := p.resolveObjectVersions(ctx, mockKvClient, kvObject)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	expected := []types.KeyVaultObject{
+		{
+			ObjectName:           "secret1",
+			ObjectType:           types.VaultObjectTypeSecret,
+			ObjectVersion:        "eligible",
+			ObjectVersionHistory: 1,
+			ObjectNotAfter:       time.Date(2026, time.June, 5, 19, 41, 0, 0, time.UTC),
+		},
+	}
+
+	if !reflect.DeepEqual(expected, resolved) {
+		t.Fatalf("expected %+v, got %+v", expected, resolved)
+	}
+}
+
 func TestFormatKeyVaultObject(t *testing.T) {
 	cases := []struct {
 		desc                   string
@@ -606,10 +702,11 @@ func TestFormatKeyVaultObject(t *testing.T) {
 		expectedKeyVaultObject types.KeyVaultObject
 	}{
 		{
-			desc: "leading and trailing whitespace trimmed from all fields",
+			desc: "leading and trailing whitespace trimmed from all string fields",
 			keyVaultObject: types.KeyVaultObject{
 				ObjectName:     "secret1     ",
 				ObjectVersion:  "",
+				ObjectNotAfter: time.Date(2026, time.June, 5, 19, 41, 0, 0, time.UTC),
 				ObjectEncoding: "base64   ",
 				ObjectType:     "  secret",
 				ObjectAlias:    "",
@@ -617,6 +714,7 @@ func TestFormatKeyVaultObject(t *testing.T) {
 			expectedKeyVaultObject: types.KeyVaultObject{
 				ObjectName:     "secret1",
 				ObjectVersion:  "",
+				ObjectNotAfter: time.Date(2026, time.June, 5, 19, 41, 0, 0, time.UTC),
 				ObjectEncoding: "base64",
 				ObjectType:     "secret",
 				ObjectAlias:    "",

--- a/pkg/provider/types/types.go
+++ b/pkg/provider/types/types.go
@@ -63,7 +63,10 @@ type KeyVaultObject struct {
 	ObjectAlias string `json:"objectAlias" yaml:"objectAlias"`
 	// the version of the Azure Key Vault objects
 	ObjectVersion string `json:"objectVersion" yaml:"objectVersion"`
+	// Ignore versions created after this RFC3339/ISO8601 timestamp
+	ObjectNotAfter time.Time `json:"objectNotAfter" yaml:"objectNotAfter"`
 	// The number of versions to load for this secret starting at the latest version
+	// or starting at the first version matched by objectNotAfter or objectVersion if specified.
 	ObjectVersionHistory int32 `json:"objectVersionHistory" yaml:"objectVersionHistory"`
 	// the type of the Azure Key Vault objects
 	ObjectType string `json:"objectType" yaml:"objectType"`
@@ -75,6 +78,11 @@ type KeyVaultObject struct {
 	ObjectEncoding string `json:"objectEncoding" yaml:"objectEncoding"`
 	// FilePermission is the file permissions
 	FilePermission string `json:"filePermission" yaml:"filePermission"`
+}
+
+func (k KeyVaultObject) WithVersion(version string) KeyVaultObject {
+	k.ObjectVersion = version
+	return k
 }
 
 // SecretFile holds content and metadata of a secret file that is sent

--- a/pkg/provider/validate.go
+++ b/pkg/provider/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 )
@@ -16,7 +17,18 @@ func validate(kv types.KeyVaultObject) error {
 	if err := validateObjectEncoding(kv.ObjectEncoding, kv.ObjectType); err != nil {
 		return err
 	}
+	if err := validateObjectVersionAndNotAfter(kv.ObjectVersion, kv.ObjectNotAfter); err != nil {
+		return err
+	}
 	return validateFileName(kv.GetFileName())
+}
+
+func validateObjectVersionAndNotAfter(objectVersion string, objectNotAfter time.Time) error {
+	if objectVersion != "" && !objectNotAfter.IsZero() {
+		return fmt.Errorf("objectVersion and objectNotAfter are mutually exclusive")
+	}
+
+	return nil
 }
 
 // validateObjectFormat checks if the object format is valid and is supported

--- a/pkg/provider/validate_test.go
+++ b/pkg/provider/validate_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestValidateObjectFormat(t *testing.T) {
@@ -139,6 +140,49 @@ func TestValidateFilePath(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := validateFileName(tc.fileName)
+			if tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() || tc.expectedErr == nil && err != nil {
+				t.Fatalf("expected err: %+v, got: %+v", tc.expectedErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateObjectVersionAndNotAfter(t *testing.T) {
+	cases := []struct {
+		desc           string
+		objectVersion  string
+		objectNotAfter time.Time
+		expectedErr    error
+	}{
+		{
+			desc:           "no objectNotAfter and no objectVersion",
+			objectVersion:  "",
+			objectNotAfter: time.Time{},
+			expectedErr:    nil,
+		},
+		{
+			desc:           "objectNotAfter set with no objectVersion",
+			objectVersion:  "",
+			objectNotAfter: time.Date(2026, time.June, 5, 19, 41, 0, 0, time.UTC),
+			expectedErr:    nil,
+		},
+		{
+			desc:           "objectNotAfter set with seconds",
+			objectVersion:  "",
+			objectNotAfter: time.Date(2026, time.June, 5, 19, 41, 30, 0, time.UTC),
+			expectedErr:    nil,
+		},
+		{
+			desc:           "objectVersion and objectNotAfter are mutually exclusive",
+			objectVersion:  "latest",
+			objectNotAfter: time.Date(2026, time.June, 5, 19, 41, 0, 0, time.UTC),
+			expectedErr:    fmt.Errorf("objectVersion and objectNotAfter are mutually exclusive"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := validateObjectVersionAndNotAfter(tc.objectVersion, tc.objectNotAfter)
 			if tc.expectedErr != nil && err.Error() != tc.expectedErr.Error() || tc.expectedErr == nil && err != nil {
 				t.Fatalf("expected err: %+v, got: %+v", tc.expectedErr, err)
 			}

--- a/test/e2e/framework/keyvault/keyvault.go
+++ b/test/e2e/framework/keyvault/keyvault.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,6 +22,8 @@ import (
 type Client interface {
 	// SetSecret sets the secret in key vault
 	SetSecret(name, value string) error
+	// GetSecretVersions gets the enabled versions of the secret in key vault
+	GetSecretVersions(name string) ([]types.KeyVaultObjectVersion, error)
 	// DeleteSecret deletes the secret in key vault
 	DeleteSecret(name string) error
 }
@@ -54,6 +58,42 @@ func (c *client) SetSecret(name, value string) error {
 	By(fmt.Sprintf("Setting secret \"%s\" in keyvault \"%s\"", name, c.config.KeyvaultName))
 	_, err := c.secretsClient.SetSecret(context.Background(), name, params, &azsecrets.SetSecretOptions{})
 	return err
+}
+
+// GetSecretVersions gets the enabled versions of the secret in key vault
+func (c *client) GetSecretVersions(name string) ([]types.KeyVaultObjectVersion, error) {
+	By(fmt.Sprintf("Getting versions for secret \"%s\" in keyvault \"%s\"", name, c.config.KeyvaultName))
+
+	pager := c.secretsClient.NewListSecretVersionsPager(name, &azsecrets.ListSecretVersionsOptions{})
+	versions := []types.KeyVaultObjectVersion{}
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			return nil, err
+		}
+
+		for _, secret := range page.SecretListResult.Value {
+			if secret.Attributes == nil {
+				continue
+			}
+			if secret.Attributes.Enabled != nil && !*secret.Attributes.Enabled {
+				continue
+			}
+
+			id := *secret.ID
+			created := date.UnixEpoch()
+			if secret.Attributes.Created != nil {
+				created = *secret.Attributes.Created
+			}
+
+			versions = append(versions, types.KeyVaultObjectVersion{
+				Version: id.Version(),
+				Created: created,
+			})
+		}
+	}
+
+	return versions, nil
 }
 
 // DeleteSecret deletes the secret in key vault

--- a/test/e2e/multiple_secret_versions_test.go
+++ b/test/e2e/multiple_secret_versions_test.go
@@ -4,7 +4,10 @@
 package e2e
 
 import (
+	"fmt"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/pkg/provider/types"
 	"github.com/Azure/secrets-store-csi-driver-provider-azure/test/e2e/framework/exec"
@@ -17,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
 )
 
@@ -194,5 +198,148 @@ var _ = Describe("[ObjectVersionHistory] When deploying SecretProviderClass CRD 
 		})
 		Expect(opaqueSecret).NotTo(BeNil())
 		Expect(opaqueSecret.Data["opaque-secret"]).NotTo(BeNil())
+	})
+})
+
+var _ = Describe("[ObjectNotAfter] When deploying SecretProviderClass CRD with secrets", func() {
+	var (
+		specName = "objectnotaftersecret"
+		ns       *corev1.Namespace
+		p        *corev1.Pod
+	)
+
+	BeforeEach(func() {
+		if config.ImageVersion < "1.3.0" {
+			Skip("functionality not yet supported in release version")
+		}
+
+		ns = namespace.CreateWithName(namespace.CreateInput{
+			Creator: kubeClient,
+			Name:    specName,
+		})
+	})
+
+	AfterEach(func() {
+		Cleanup(CleanupInput{
+			Namespace: ns,
+			Getter:    kubeClient,
+			Lister:    kubeClient,
+			Deleter:   kubeClient,
+		})
+	})
+
+	It("should read latest secret version created not after timestamp", func() {
+		if config.IsKindCluster {
+			Skip("test case not supported for kind cluster")
+		}
+
+		secretName := fmt.Sprintf("secret-na-%s", utilrand.String(5))
+		err := kvClient.SetSecret(secretName, "old")
+		Expect(err).To(BeNil())
+		defer func() {
+			err = kvClient.DeleteSecret(secretName)
+			Expect(err).To(BeNil())
+		}()
+
+		err = kvClient.SetSecret(secretName, "selected")
+		Expect(err).To(BeNil())
+
+		var versions []types.KeyVaultObjectVersion
+		Eventually(func() int {
+			versions, err = kvClient.GetSecretVersions(secretName)
+			Expect(err).To(BeNil())
+			return len(versions)
+		}, 1*time.Minute, 5*time.Second).Should(Equal(2))
+		Expect(versions).To(HaveLen(2))
+		sort.Sort(types.KeyVaultObjectVersionList(versions))
+		objectNotAfter := versions[0].Created
+
+		time.Sleep(2 * time.Second)
+
+		err = kvClient.SetSecret(secretName, "too-new")
+		Expect(err).To(BeNil())
+
+		Eventually(func() bool {
+			versions, err = kvClient.GetSecretVersions(secretName)
+			if err != nil || len(versions) != 3 {
+				return false
+			}
+
+			sort.Sort(types.KeyVaultObjectVersionList(versions))
+			return versions[0].Created.After(objectNotAfter)
+		}, 1*time.Minute, 5*time.Second).Should(BeTrue())
+
+		keyVaultObjects := []types.KeyVaultObject{
+			{
+				ObjectName:     secretName,
+				ObjectType:     types.VaultObjectTypeSecret,
+				ObjectAlias:    "not-after-single",
+				ObjectNotAfter: objectNotAfter,
+			},
+			{
+				ObjectName:           secretName,
+				ObjectType:           types.VaultObjectTypeSecret,
+				ObjectAlias:          "not-after-history",
+				ObjectNotAfter:       objectNotAfter,
+				ObjectVersionHistory: 2,
+			},
+		}
+
+		yamlArray := types.StringArray{Array: []string{}}
+		for _, object := range keyVaultObjects {
+			obj, err := yaml.Marshal(object)
+			Expect(err).To(BeNil())
+			yamlArray.Array = append(yamlArray.Array, string(obj))
+		}
+
+		objects, err := yaml.Marshal(yamlArray)
+		Expect(err).To(BeNil())
+
+		spc := secretproviderclass.Create(secretproviderclass.CreateInput{
+			Creator:   kubeClient,
+			Config:    config,
+			Name:      "azure",
+			Namespace: ns.Name,
+			Spec: v1alpha1.SecretProviderClassSpec{
+				Provider: "azure",
+				Parameters: map[string]string{
+					"keyvaultName": config.KeyvaultName,
+					"tenantId":     config.TenantID,
+					"objects":      string(objects),
+					"clientID":     config.AzureClientID,
+				},
+			},
+		})
+
+		p = pod.Create(pod.CreateInput{
+			Creator:                 kubeClient,
+			Config:                  config,
+			Name:                    "busybox-secrets-store-inline-crd",
+			Namespace:               ns.Name,
+			SecretProviderClassName: spc.Name,
+		})
+
+		pod.WaitFor(pod.WaitForInput{
+			Getter:         kubeClient,
+			KubeconfigPath: kubeconfigPath,
+			Config:         config,
+			PodName:        p.Name,
+			Namespace:      ns.Name,
+		})
+
+		cmd := getPodExecCommand("cat /mnt/secrets-store/not-after-single")
+		secret, err := exec.KubectlExec(kubeconfigPath, p.Name, p.Namespace, strings.Split(cmd, " "))
+		Expect(err).To(BeNil())
+		Expect(secret).To(Equal("selected"))
+
+		cmd = getPodExecCommand("cat /mnt/secrets-store/not-after-history/0")
+		secret, err = exec.KubectlExec(kubeconfigPath, p.Name, p.Namespace, strings.Split(cmd, " "))
+		Expect(err).To(BeNil())
+		Expect(secret).To(Equal("selected"))
+
+		cmd = getPodExecCommand("cat /mnt/secrets-store/not-after-history/1")
+		secret, err = exec.KubectlExec(kubeconfigPath, p.Name, p.Namespace, strings.Split(cmd, " "))
+		Expect(err).To(BeNil())
+		Expect(secret).To(Equal("old"))
 	})
 })

--- a/website/content/en/configurations/sync-multiple-versions.md
+++ b/website/content/en/configurations/sync-multiple-versions.md
@@ -29,6 +29,7 @@ spec:
           objectType: secret                     # object types: secret, key or cert
           objectAlias: secretalias
           objectVersion: $SECRET_VERSION         # [OPTIONAL] object versions, default to latest if empty
+          objectNotAfter: ""                     # [OPTIONAL] RFC3339 timestamp. Select the latest version created at or before this timestamp. Mutually exclusive with objectVersion.
           objectVersionHistory: 5                # The number of versions to sync (including the specified version)
         - |
           objectName: $KEY_NAME
@@ -70,6 +71,8 @@ In some cases, you may need to sync the latest N versions of a secret. Use the o
 When you do this, the provider will treat the object name/alias as a folder and place the top N (where N is `objectVersionHistory`) versions of the secret (sorted by secret creation date) into that folder. The file name for each version will be an integer, starting with `0` for the specified version, `1` for the next most recent, and so on.
 
 > NOTE: If you specify a version, the provider will sync the top N starting with that specified version. If you do not specify a version, or specify `latest`, then it will sync the most recent N as determined by the secret creation date.
+
+> NOTE: If you specify `objectNotAfter`, the provider will ignore versions created after that RFC3339 timestamp and start with the newest version created at or before the timestamp. `objectNotAfter` and `objectVersion` are mutually exclusive.
 
 > NOTE: If you are syncing this secret with a Kubernetes secret, make sure the `objectName` in `secretObjects` also indicates which version of the secret to sync (i.e., `foosecret/0` instead of just `foosecret`)
 

--- a/website/content/en/getting-started/usage/_index.md
+++ b/website/content/en/getting-started/usage/_index.md
@@ -52,6 +52,7 @@ To provide identity to access Key Vault, refer to the following [section](#provi
             objectAlias: SECRET_1           # [OPTIONAL available for version > 0.0.4] object alias
             objectType: secret              # object types: secret, key or cert. For Key Vault certificates, refer to https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/configurations/getting-certs-and-keys/ for the object type to use
             objectVersion: ""               # [OPTIONAL] object versions, default to latest if empty
+            objectNotAfter: ""              # [OPTIONAL] RFC3339 timestamp. Select the latest version created at or before this timestamp. Mutually exclusive with objectVersion.
             objectVersionHistory: 5         # [OPTIONAL] if greater than 1, the number of versions to sync starting at the specified version.
             filePermission: 0755                # [OPTIONAL] permission for secret file being mounted into the pod, default is 0644 if not specified.
           - |
@@ -79,6 +80,7 @@ To provide identity to access Key Vault, refer to the following [section](#provi
   | objectAlias            | no       | [__*available for version > 0.0.4*__] specify the filename of the object when written to disk - defaults to objectName if not provided                                                                                 | ""            |
   | objectType             | yes      | type of a Key Vault object: secret, key or cert.<br>For Key Vault certificates, refer to [doc](../../configurations/getting-certs-and-keys) for the object type to use.</br>                                           | ""            |
   | objectVersion          | no       | version of a Key Vault object, if not provided, will use latest                                                                                                                                                        | ""            |
+  | objectNotAfter         | no       | [__*available for version > v1.3.0*__] RFC3339 timestamp used to select the latest Key Vault object version created at or before that time. Mutually exclusive with `objectVersion`                                   | ""            |
   | objectVersionHistory   | no       | [__*available for version > v1.3.0*__] number of previous versions to sync, if not provided, will only sync the specified versions                                                                                                                                                      | 0             |
   | objectFormat           | no       | [__*available for version > 0.0.7*__] the format of the Azure Key Vault object, supported types are pem and pfx. `objectFormat: pfx` is only supported with `objectType: secret` and PKCS12 or ECC certificates        | "pem"         |
   | objectEncoding         | no       | [__*available for version > 0.0.8*__] the encoding of the Azure Key Vault secret object, supported types are `utf-8`, `hex` and `base64`. This option is supported only with `objectType: secret`                      | "utf-8"       |
@@ -137,6 +139,8 @@ To validate, once the pod is started, you should see the new mounted content at 
 #### Syncing Multiple Versions of a Secret
 
 The Azure Key Vault Provider allows syncing previous versions of a secret via the `objectVersionHistory` property. If this property is specified, and the value is greater than 1, the provider will sync up to that many versions of the specified secret starting with the version specified. The file name for each version of the secret will be `{objectAlias}/{versionIndex}` where version index is the 0-based starting with the latest version.
+
+You can use `objectNotAfter` instead of `objectVersion` to select versions by creation time. When set to an RFC3339 timestamp, the provider ignores versions created after that timestamp and starts with the newest version created at or before it.
 
 If you want to sync one of these versions with a kubernetes secret, the only difference is that you have to specify which version you want (i.e., to use the latest version, you specify `{objectAlias}/0` in `[secretObjects].[objectName]`)
 


### PR DESCRIPTION
<!-- Thank you for helping Azure Key Vault Provider for Secrets Store CSI Driver with a pull request! Please make sure you read the [contributing guidelines](https://github.com/Azure/secrets-store-csi-driver-provider-azure#contributing). -->

**Reason for Change**:
<!-- What does this PR improve or fix in Azure Key Vault Provider for Secrets Store CSI Driver? Why is it needed? -->

Reasons explained in #2039 

<!--
**Is this a chart or deployment yaml update?**
If yes, please update the yamls in the [manifest_staging/](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/) folder, where we host the staging charts and deployment yamls. All the yaml changes will then be promoted into the released charts folder with the next release. Please also add the new configurable values to the configuration [table](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/manifest_staging/charts/csi-secrets-store-provider-azure#configuration). 
-->

**Requirements**

- [x] squashed commits
- [x] included documentation
- [x] added unit tests and e2e tests (if applicable).


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

Fixes #2039 

**Does this change contain code from or inspired by another project?**

- [ ] Yes
- [x] No

**If "Yes," did you notify that project's maintainers and provide attribution?**

**Special Notes for Reviewers**:
